### PR TITLE
make sure there is an activity.

### DIFF
--- a/android/src/main/java/vn/hunghd/flutterdownloader/FlutterDownloaderPlugin.java
+++ b/android/src/main/java/vn/hunghd/flutterdownloader/FlutterDownloaderPlugin.java
@@ -64,7 +64,9 @@ public class FlutterDownloaderPlugin implements MethodCallHandler, Application.A
     @SuppressLint("NewApi")
     public static void registerWith(PluginRegistry.Registrar registrar) {
         final FlutterDownloaderPlugin plugin = new FlutterDownloaderPlugin(registrar.context(), registrar.messenger());
-        registrar.activity().getApplication().registerActivityLifecycleCallbacks(plugin);
+        if(registrar.activity() != null){
+            registrar.activity().getApplication().registerActivityLifecycleCallbacks(plugin);
+        }
     }
 
     @Override


### PR DESCRIPTION
This fixes a crash if the parent project uses a custom MainApplication class.