### PR TITLE
Added Title option when opening files on iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,10 +256,12 @@ FlutterDownloader.remove(taskId: taskId, shouldDeleteContent:false);
 #### Open and preview a downloaded file:
 
 ````dart
-FlutterDownloader.open(taskId: taskId);
+FlutterDownloader.open(taskId: taskId, title: "Title (Optional)");
 ````
 
-- Note: in Android, you can only open a downloaded file if it is placed in the external storage and there's at least one application that can read that file type on your device.
+**Note:**
+ - In Android, you can only open a downloaded file if it is placed in the external storage and there's at least one application that can read that file type on your device.
+ - The title option is only supported in iOS.
 
 ## Bugs/Requests
 If you encounter any problems feel free to open an issue. If you feel the library is

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -382,7 +382,7 @@ class _MyHomePageState extends State<MyHomePage> with WidgetsBindingObserver {
   }
 
   Future<bool> _openDownloadedFile(_TaskInfo task) {
-    return FlutterDownloader.open(taskId: task.taskId);
+    return FlutterDownloader.open(taskId: task.taskId, title: "Title (Optional)");
   }
 
   void _delete(_TaskInfo task) async {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -382,7 +382,7 @@ class _MyHomePageState extends State<MyHomePage> with WidgetsBindingObserver {
   }
 
   Future<bool> _openDownloadedFile(_TaskInfo task) {
-    return FlutterDownloader.open(taskId: task.taskId, title: "Title (Optional)");
+    return FlutterDownloader.open(taskId: task.taskId, title: task.name);
   }
 
   void _delete(_TaskInfo task) async {

--- a/ios/Classes/FlutterDownloaderPlugin.m
+++ b/ios/Classes/FlutterDownloaderPlugin.m
@@ -23,6 +23,7 @@
 #define KEY_OPEN_FILE_FROM_NOTIFICATION @"open_file_from_notification"
 #define KEY_QUERY @"query"
 #define KEY_TIME_CREATED @"time_created"
+#define KEY_TITLE @"title"
 
 #define NULL_VALUE @"<null>"
 
@@ -216,11 +217,15 @@
     [_flutterChannel invokeMethod:@"updateProgress" arguments:info];
 }
 
-- (BOOL)openDocumentWithURL:(NSURL*)url {
+- (BOOL)openDocumentWithURL:(NSURL*)url title: (NSString*) title {
     NSLog(@"try to open file in url: %@", url);
     BOOL result = NO;
     UIDocumentInteractionController* tmpDocController = [UIDocumentInteractionController
                                                          interactionControllerWithURL:url];
+    
+    if (title != (NSString*) [NSNull null] && ![NULL_VALUE isEqualToString: title]) {
+        tmpDocController.name = title;
+    }
     if (tmpDocController)
     {
         NSLog(@"initialize UIDocumentInteractionController successfully");
@@ -547,13 +552,14 @@
 
 - (void)openMethodCall:(FlutterMethodCall*)call result:(FlutterResult)result {
     NSString *taskId = call.arguments[KEY_TASK_ID];
+    NSString *title = call.arguments[KEY_TITLE];
     NSDictionary* taskDict = [self loadTaskWithId:taskId];
     if (taskDict != nil) {
         NSNumber* status = taskDict[KEY_STATUS];
         if ([status intValue] == STATUS_COMPLETE) {
             NSURL *downloadedFileURL = [self fileUrlFromDict:taskDict];
 
-            BOOL success = [self openDocumentWithURL:downloadedFileURL];
+            BOOL success = [self openDocumentWithURL:downloadedFileURL title:title];
             result([NSNumber numberWithBool:success]);
         } else {
             result([FlutterError errorWithCode:@"invalid_status"

--- a/lib/flutter_downloader.dart
+++ b/lib/flutter_downloader.dart
@@ -343,9 +343,9 @@ class FlutterDownloader {
   /// - The current device has at least an application that can read the file
   /// type of the file
   ///
-  static Future<bool> open({@required String taskId}) async {
+  static Future<bool> open({@required String taskId, String title}) async {
     try {
-      return await platform.invokeMethod('open', {'task_id': taskId});
+      return await platform.invokeMethod('open', {'task_id': taskId, 'title': title});
     } on PlatformException catch (e) {
       print(e.message);
       return false;


### PR DESCRIPTION
Small improvement that lets you specify a title to use when opening files on iOS instead of showing the filename.

Example Screenshot:
![Simulator Screen Shot - iPhone X - 2019-06-06 at 11 56 34](https://user-images.githubusercontent.com/4108718/59047649-43efde00-8852-11e9-9fd6-31fee04f4aa6.png)
