### PR TITLE
fix apk file open fails in some cases

### DIFF
--- a/android/src/main/java/vn/hunghd/flutterdownloader/DownloadWorker.java
+++ b/android/src/main/java/vn/hunghd/flutterdownloader/DownloadWorker.java
@@ -276,8 +276,8 @@ public class DownloadWorker extends Worker {
                 int storage = ContextCompat.checkSelfPermission(getApplicationContext(), android.Manifest.permission.WRITE_EXTERNAL_STORAGE);
                 PendingIntent pendingIntent = null;
                 if (status == DownloadStatus.COMPLETE && clickToOpenDownloadedFile && storage == PackageManager.PERMISSION_GRANTED) {
-                    Intent intent = IntentUtils.getOpenFileIntent(getApplicationContext(), saveFilePath, contentType);
-                    if (IntentUtils.validateIntent(getApplicationContext(), intent)) {
+                    Intent intent = IntentUtils.validatedFileIntent(getApplicationContext(), saveFilePath, contentType);
+                    if (intent != null) {
                         Log.d(TAG, "Setting an intent to open the file " + saveFilePath);
                         pendingIntent = PendingIntent.getActivity(getApplicationContext(), 0, intent, PendingIntent.FLAG_CANCEL_CURRENT);
                     } else {

--- a/android/src/main/java/vn/hunghd/flutterdownloader/FlutterDownloaderPlugin.java
+++ b/android/src/main/java/vn/hunghd/flutterdownloader/FlutterDownloaderPlugin.java
@@ -295,8 +295,8 @@ public class FlutterDownloaderPlugin implements MethodCallHandler, Application.A
                     filename = fileURL.substring(fileURL.lastIndexOf("/") + 1, fileURL.length());
                 }
                 String saveFilePath = savedDir + File.separator + filename;
-                Intent intent = IntentUtils.getOpenFileIntent(context, saveFilePath, task.mimeType);
-                if (IntentUtils.validateIntent(context, intent)) {
+                Intent intent = IntentUtils.validatedFileIntent(context, saveFilePath, task.mimeType);
+                if (intent!=null) {
                     context.startActivity(intent);
                     result.success(true);
                 } else {

--- a/android/src/main/java/vn/hunghd/flutterdownloader/IntentUtils.java
+++ b/android/src/main/java/vn/hunghd/flutterdownloader/IntentUtils.java
@@ -5,13 +5,15 @@ import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
 import android.net.Uri;
+import android.os.Build;
+
 import androidx.core.content.FileProvider;
 
+import java.io.BufferedInputStream;
 import java.io.File;
+import java.io.FileInputStream;
+import java.net.URLConnection;
 import java.util.List;
-
-import android.util.Log;
-import android.os.Build;
 
 public class IntentUtils {
     

--- a/android/src/main/java/vn/hunghd/flutterdownloader/IntentUtils.java
+++ b/android/src/main/java/vn/hunghd/flutterdownloader/IntentUtils.java
@@ -38,9 +38,10 @@ public class IntentUtils {
         String mime = null;
         try {
             FileInputStream inputFile = new FileInputStream(path);
-            mime = URLConnection.guessContentTypeFromStream(inputFile);
+            mime = URLConnection.guessContentTypeFromStream(inputFile);//does not work in some target sdk version
             if(mime==null){
-                mime = URLConnection.guessContentTypeFromStream(new BufferedInputStream(inputFile));
+                mime = URLConnection.guessContentTypeFromName(path);//works fine
+
             }
         } catch (Exception ignored){
 

--- a/android/src/main/java/vn/hunghd/flutterdownloader/IntentUtils.java
+++ b/android/src/main/java/vn/hunghd/flutterdownloader/IntentUtils.java
@@ -14,14 +14,9 @@ import android.util.Log;
 import android.os.Build;
 
 public class IntentUtils {
-    private static final String TYPE_STRING_APK = "application/vnd.android.package-archive";
-
     public static synchronized Intent getOpenFileIntent(Context context, String path, String contentType) {
         File file = new File(path);
         Intent intent = new Intent(Intent.ACTION_VIEW);
-        boolean isApkFile = contentType.startsWith(TYPE_STRING_APK) || path.endsWith(".apk");
-        if(isApkFile)
-            contentType = TYPE_STRING_APK;
         if (Build.VERSION.SDK_INT >= 24) {
             Uri uri = FileProvider.getUriForFile(
                     context,

--- a/android/src/main/java/vn/hunghd/flutterdownloader/IntentUtils.java
+++ b/android/src/main/java/vn/hunghd/flutterdownloader/IntentUtils.java
@@ -14,11 +14,14 @@ import android.util.Log;
 import android.os.Build;
 
 public class IntentUtils {
+    private static final String TYPE_STRING_APK = "application/vnd.android.package-archive";
 
     public static synchronized Intent getOpenFileIntent(Context context, String path, String contentType) {
         File file = new File(path);
         Intent intent = new Intent(Intent.ACTION_VIEW);
-
+        boolean isApkFile = contentType.startsWith(TYPE_STRING_APK) || path.endsWith(".apk");
+        if(isApkFile)
+            contentType = TYPE_STRING_APK;
         if (Build.VERSION.SDK_INT >= 24) {
             Uri uri = FileProvider.getUriForFile(
                     context,

--- a/android/src/main/java/vn/hunghd/flutterdownloader/IntentUtils.java
+++ b/android/src/main/java/vn/hunghd/flutterdownloader/IntentUtils.java
@@ -25,7 +25,7 @@ public class IntentUtils {
         }
         intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
         intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
-        if(validateIntent(context, intent)
+        if(validateIntent(context, intent))
             return intent;
         return null;
     }
@@ -43,7 +43,7 @@ public class IntentUtils {
                 mime = URLConnection.guessContentTypeFromStream(new BufferedInputStream(inputFile));
             }
         } catch (Exception ignored){
-            
+
         }
         if(mime!=null) {
             intent = buildIntent(context,file,mime);
@@ -51,7 +51,8 @@ public class IntentUtils {
                 return intent;
         }
         return null;
-//     }
+    }
+    
 //     public static synchronized Intent getOpenFileIntent(Context context, String path, String contentType) {
 //         File file = new File(path);
 //         Intent intent = new Intent(Intent.ACTION_VIEW);

--- a/android/src/main/java/vn/hunghd/flutterdownloader/IntentUtils.java
+++ b/android/src/main/java/vn/hunghd/flutterdownloader/IntentUtils.java
@@ -14,24 +14,62 @@ import android.util.Log;
 import android.os.Build;
 
 public class IntentUtils {
-    public static synchronized Intent getOpenFileIntent(Context context, String path, String contentType) {
-        File file = new File(path);
+    
+    private static Intent buildIntent(Context context, File file, String mime){
         Intent intent = new Intent(Intent.ACTION_VIEW);
-        if (Build.VERSION.SDK_INT >= 24) {
-            Uri uri = FileProvider.getUriForFile(
-                    context,
-                    context.getPackageName() + ".flutter_downloader.provider", file);
-            intent.setDataAndType(uri, contentType);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            Uri uri = FileProvider.getUriForFile(context, context.getPackageName() + ".flutter_downloader.provider", file);
+            intent.setDataAndType(uri, mime);
         } else {
-            intent.setDataAndType(Uri.fromFile(file), contentType);
+            intent.setDataAndType(Uri.fromFile(file), mime);
         }
-
         intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
         intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
-        return intent;
+        if(validateIntent(context, intent)
+            return intent;
+        return null;
     }
 
-    public static synchronized boolean validateIntent(Context context, Intent intent) {
+    public static synchronized Intent validatedFileIntent(Context context, String path, String contentType) {
+        File file = new File(path);
+        Intent intent = buildIntent(context,file,contentType);
+        if(validateIntent(context, intent))
+            return intent;
+        String mime = null;
+        try {
+            FileInputStream inputFile = new FileInputStream(path);
+            mime = URLConnection.guessContentTypeFromStream(inputFile);
+            if(mime !=null){
+                mime = URLConnection.guessContentTypeFromStream(new BufferedInputStream(inputFile));
+            }
+        } catch (Exception ignored){
+            
+        }
+        if(mime!=null) {
+            intent = buildIntent(context,file,mime);
+            if(validateIntent(context, intent))
+                return intent;
+        }
+        return null;
+//     }
+//     public static synchronized Intent getOpenFileIntent(Context context, String path, String contentType) {
+//         File file = new File(path);
+//         Intent intent = new Intent(Intent.ACTION_VIEW);
+//         if (Build.VERSION.SDK_INT >= 24) {
+//             Uri uri = FileProvider.getUriForFile(
+//                     context,
+//                     context.getPackageName() + ".flutter_downloader.provider", file);
+//             intent.setDataAndType(uri, contentType);
+//         } else {
+//             intent.setDataAndType(Uri.fromFile(file), contentType);
+//         }
+
+//         intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+//         intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+//         return intent;
+//     }
+
+    private static boolean validateIntent(Context context, Intent intent) {
         PackageManager manager = context.getPackageManager();
         List<ResolveInfo> infos = manager.queryIntentActivities(intent, 0);
         if (infos.size() > 0) {

--- a/android/src/main/java/vn/hunghd/flutterdownloader/IntentUtils.java
+++ b/android/src/main/java/vn/hunghd/flutterdownloader/IntentUtils.java
@@ -39,7 +39,7 @@ public class IntentUtils {
         try {
             FileInputStream inputFile = new FileInputStream(path);
             mime = URLConnection.guessContentTypeFromStream(inputFile);
-            if(mime !=null){
+            if(mime==null){
                 mime = URLConnection.guessContentTypeFromStream(new BufferedInputStream(inputFile));
             }
         } catch (Exception ignored){

--- a/android/src/main/java/vn/hunghd/flutterdownloader/IntentUtils.java
+++ b/android/src/main/java/vn/hunghd/flutterdownloader/IntentUtils.java
@@ -25,9 +25,7 @@ public class IntentUtils {
         }
         intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
         intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
-        if(validateIntent(context, intent))
-            return intent;
-        return null;
+        return intent;
     }
 
     public static synchronized Intent validatedFileIntent(Context context, String path, String contentType) {


### PR DESCRIPTION
Some apk file's mimeType ends with charset,such as "application/vnd.android.package-archive;charset=utf8" which cause the indent `setDataAndType`  with wrong type. In my project, `validateIntent`(Intent with mixed mimeType) fails