### PR TITLE
set default for flutter.versionCode and flutter.versionName

### DIFF
--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -13,12 +13,12 @@ if (flutterRoot == null) {
 
 def flutterVersionCode = localProperties.getProperty('flutter.versionCode')
 if (flutterVersionCode == null) {
-    throw new GradleException("versionCode not found. Define flutter.versionCode in the local.properties file.")
+    flutterVersionCode = '1'
 }
 
 def flutterVersionName = localProperties.getProperty('flutter.versionName')
 if (flutterVersionName == null) {
-    throw new GradleException("versionName not found. Define flutter.versionName in the local.properties file.")
+    flutterVersionName = '1.0'
 }
 
 apply plugin: 'com.android.application'


### PR DESCRIPTION
set default for `flutter.versionCode` and `flutter.versionName` instead of throwing an exception, because those two variables are retrieved from `android/local.properties` file which it does not have them from the first time (they should be set manually) that is why newcomers have problem running the code example https://github.com/fluttercommunity/flutter_downloader/issues/91#issuecomment-524598339
Also this setup is being the default for now once you run `flutter create` 

