### PR TITLE
Fixing "Download failed" by permissions check for image/video

### DIFF
--- a/android/src/main/java/vn/hunghd/flutterdownloader/DownloadWorker.java
+++ b/android/src/main/java/vn/hunghd/flutterdownloader/DownloadWorker.java
@@ -279,7 +279,16 @@ public class DownloadWorker extends Worker {
                 PendingIntent pendingIntent = null;
                 if (status == DownloadStatus.COMPLETE) {
                     if (isImageOrVideoFile(contentType)) {
-                        addImageOrVideoToGallery(filename, saveFilePath, getContentTypeWithoutCharset(contentType));
+                        try {
+                            addImageOrVideoToGallery(filename, saveFilePath, getContentTypeWithoutCharset(contentType));
+                        } catch (SecurityException e) {
+                            Log.d(
+                                    TAG,
+                                    "Not enough permissions to add image/video to gallery." +
+                                            " Path: " + saveFilePath +
+                                            " Error: " + e.getMessage()
+                            );
+                        }
                     }
 
                     if (clickToOpenDownloadedFile && storage == PackageManager.PERMISSION_GRANTED) {


### PR DESCRIPTION
If downloading images or videos to app private storage (like ApplicationDocumentsDirectory), the call to addImageOrVideoToGallery() caused download to fail with a SecurityException (on Android).
This is fixed by this pull request by catching the exception. (it'd may be cleaner to check the permissions before calling addImageOrVideoToGallery(), but this way it's failsafe.)