### PR TITLE
Initialize() should not be called more than once

### DIFF
--- a/lib/src/downloader.dart
+++ b/lib/src/downloader.dart
@@ -26,6 +26,8 @@ class FlutterDownloader {
   static bool _initialized = false;
 
   static Future<Null> initialize() async {
+    assert(!_initialized, 'FlutterDownloader.initialize() must be called only once!');
+
     final callback = PluginUtilities.getCallbackHandle(callbackDispatcher);
     await _channel
         .invokeMethod('initialize', <dynamic>[callback.toRawHandle()]);


### PR DESCRIPTION
Add an assert checking that `FlutterDownloader.initialize()` is not called more than once, because that may end up registering plugins multiple times and crashing the app.

Related to #154.