### PR TITLE
Updated constant path separator in Flutter example

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -494,7 +494,7 @@ class _MyHomePageState extends State<MyHomePage> {
 
     _permissionReady = await _checkPermission();
 
-    _localPath = (await _findLocalPath()) + '/Download';
+    _localPath = (await _findLocalPath()) + Platform.pathSeparator + 'Download';
 
     final savedDir = Directory(_localPath);
     bool hasExisted = await savedDir.exists();


### PR DESCRIPTION
The path separator used by the operating system to separate components in file paths.

From the [docs](https://api.dart.dev/stable/2.7.0/dart-io/Platform/pathSeparator.html)