### PR TITLE
Ensures native system is initialized. Android only.

### DIFF
--- a/android/src/main/java/vn/hunghd/flutterdownloader/DownloadWorker.java
+++ b/android/src/main/java/vn/hunghd/flutterdownloader/DownloadWorker.java
@@ -105,6 +105,7 @@ public class DownloadWorker extends Worker implements MethodChannel.MethodCallHa
                 SharedPreferences pref = context.getSharedPreferences(FlutterDownloaderPlugin.SHARED_PREFERENCES_KEY, Context.MODE_PRIVATE);
                 long callbackHandle = pref.getLong(FlutterDownloaderPlugin.CALLBACK_DISPATCHER_HANDLE_KEY, 0);
 
+                FlutterMain.startInitialization(context); // Starts initialization of the native system, if already initialized this does nothing
                 FlutterMain.ensureInitializationComplete(context, null);
 
                 FlutterCallbackInformation callbackInfo = FlutterCallbackInformation.lookupCallbackInformation(callbackHandle);


### PR DESCRIPTION
Fixes issue #228

Ensure the native Android initialization process is started before calling FlutterMain.ensureInitializationComplete. During testing it was discovered in certain circumstances this was not the case and the app would crash. Call the initialization multiple times does nothing.

See docs:
[https://api.flutter.dev/javadoc/io/flutter/view/FlutterMain.html#startInitialization-android.content.Context-](https://api.flutter.dev/javadoc/io/flutter/view/FlutterMain.html#startInitialization-android.content.Context-)

[https://github.com/flutter/engine/blob/9acec4102a3536e41287704d33640dc8ff54e67f/shell/platform/android/io/flutter/embedding/engine/loader/FlutterLoader.java](https://github.com/flutter/engine/blob/9acec4102a3536e41287704d33640dc8ff54e67f/shell/platform/android/io/flutter/embedding/engine/loader/FlutterLoader.java)

Edit: url of links corrected