### PR TITLE
Add HTTP 303 to redirect group

### DIFF
--- a/android/src/main/java/vn/hunghd/flutterdownloader/DownloadWorker.java
+++ b/android/src/main/java/vn/hunghd/flutterdownloader/DownloadWorker.java
@@ -275,6 +275,7 @@ public class DownloadWorker extends Worker implements MethodChannel.MethodCallHa
                 responseCode = httpConn.getResponseCode();
                 switch (responseCode) {
                     case HttpURLConnection.HTTP_MOVED_PERM:
+                    case HttpURLConnection.HTTP_SEE_OTHER:    
                     case HttpURLConnection.HTTP_MOVED_TEMP:
                         Log.d(TAG, "Response with redirection code");
                         location = httpConn.getHeaderField("Location");


### PR DESCRIPTION
Currently, there are only two HTTP codes considered as redirect codes, but we have HTTP 303 `SEE OTHER` in addition to them. Without it the downloader cancels the request.