### PR TITLE
To support use from isolation, do not use singleton. (iOS)

### DIFF
--- a/ios/Classes/FlutterDownloaderPlugin.m
+++ b/ios/Classes/FlutterDownloaderPlugin.m
@@ -51,7 +51,6 @@
 
 @implementation FlutterDownloaderPlugin
 
-static FlutterDownloaderPlugin *instance = nil;
 static FlutterPluginRegistrantCallback registerPlugins = nil;
 static BOOL initialized = NO;
 
@@ -733,12 +732,7 @@ static BOOL initialized = NO;
 # pragma mark - FlutterPlugin
 
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar>*)registrar {
-    @synchronized(self) {
-        if (instance == nil) {
-            instance = [[FlutterDownloaderPlugin alloc] init:registrar];
-            [registrar addApplicationDelegate: instance];
-        }
-    }
+    [registrar addApplicationDelegate: [[FlutterDownloaderPlugin alloc] init:registrar]];
 }
 
 + (void)setPluginRegistrantCallback:(FlutterPluginRegistrantCallback)callback {


### PR DESCRIPTION
If the plugin is singleton and use this plugin from 2 or more isolates, it causes MisiingPluginException(No implementation found for method initialize on channel vn.hunghd/downloader).

Android plugin is already not singleton due to flutter android v2 embedding.