### PR TITLE
Fix enqueue, resume and retry callback for Android.

### DIFF
--- a/lib/src/downloader.dart
+++ b/lib/src/downloader.dart
@@ -386,6 +386,22 @@ class FlutterDownloader {
   static registerCallback(DownloadCallback callback) {
     assert(_initialized, 'FlutterDownloader.initialize() must be called first');
 
+    if (callback != null) {
+      // remove previous setting
+      _channel.setMethodCallHandler(null);
+      _channel.setMethodCallHandler((MethodCall call) async {
+        if (call.method == 'updateProgress') {
+          String id = call.arguments['task_id'];
+          int status = call.arguments['status'];
+          int process = call.arguments['progress'];
+          callback(id, DownloadTaskStatus(status), process);
+        }
+        return null;
+      });
+    } else {
+      _channel.setMethodCallHandler(null);
+    }
+
     final callbackHandle = PluginUtilities.getCallbackHandle(callback);
     assert(callbackHandle != null,
         'callback must be a top-level or a static function');


### PR DESCRIPTION
In Android, it seems that the callback registered by FlutterDownloader.registerCallback method does not work with enqueue, resume and retry.
Because [sendUpdateProgress](https://github.com/fluttercommunity/flutter_downloader/blob/e3443037be61fb87f455c6a5d5567124b237b91a/android/src/main/java/vn/hunghd/flutterdownloader/FlutterDownloaderPlugin.java#L139) does not work due to there is no handler for "updateProgress".
I look back the code history and find that before commit 03544c7e0e9e0a0e73b45d66a65cd4b48f79902f it was handle at [FlutterDownloader.registerCallback](https://github.com/fluttercommunity/flutter_downloader/blob/312efe733684818f37c9f976677d12a21ccfc3bc/lib/flutter_downloader.dart#L390).
So I put that code to the same place.

This could fixes #191 