### PR TITLE
Update gradle.properties to enable androidX support

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,1 +1,3 @@
 org.gradle.jvmargs=-Xmx1536M
+android.enableJetifier=true
+android.useAndroidX=true


### PR DESCRIPTION
For AndroidX support there need to be two additional lines in the gradle.properties. I have added them. Please accept this PR