### PR TITLE
Document exactly what update time is

### DIFF
--- a/lib/src/models.dart
+++ b/lib/src/models.dart
@@ -35,6 +35,7 @@ class DownloadTaskStatus {
 /// * [url] the download link
 /// * [filename] the local file name of a downloaded file
 /// * [savedDir] the absolute path of the directory where the downloaded file is saved
+/// * [timeCreated] milliseconds since the Unix epoch (midnight, January 1, 1970 UTC)
 ///
 class DownloadTask {
   final String taskId;


### PR DESCRIPTION
I didn't think it was so clear what updateTime was. I figured it was either seconds or milliseconds since unix epoch, but wasn't sure which, and it makes a difference.
The implementation uses java.lang.System.currentTimeMillis(), which returns milliseconds since epoch, so I updated docs accordingly