### PR TITLE
Add automatic resume for unexpectedly killed works.

### DIFF
--- a/android/src/main/java/vn/hunghd/flutterdownloader/DownloadWorker.java
+++ b/android/src/main/java/vn/hunghd/flutterdownloader/DownloadWorker.java
@@ -189,6 +189,14 @@ public class DownloadWorker extends Worker implements MethodChannel.MethodCallHa
         updateNotification(context, filename == null ? url : filename, DownloadStatus.RUNNING, task.progress, null, false);
         taskDao.updateTask(getId().toString(), DownloadStatus.RUNNING, task.progress);
 
+        //automatic resume for partial files. (if the workmanager unexpectedly quited in background)
+        String saveFilePath = savedDir + File.separator + filename;
+        File partialFile = new File(saveFilePath);
+        if (partialFile.exists()) {
+            isResume = true;
+            log("exists file for "+ filename + "automatic resuming...");
+        }
+
         try {
             downloadFile(context, url, savedDir, filename, headers, isResume);
             cleanUp();


### PR DESCRIPTION
Use case: 
on Android, When app is force quit and restarted work is rescheduled,  so the work is in running state again but starts with 0% abandoning the partially downloaded file.

see this for reference:
https://stackoverflow.com/questions/50682061/android-is-workmanager-running-when-app-is-closed


_App info "Force stop":
Work stops, will only continue when app is started again_

so there needs a way to resume partially downloaded files.