### PR TITLE
Fix wrong base URL on Redirect multiple url

### DIFF
--- a/android/src/main/java/vn/hunghd/flutterdownloader/DownloadWorker.java
+++ b/android/src/main/java/vn/hunghd/flutterdownloader/DownloadWorker.java
@@ -284,7 +284,7 @@ public class DownloadWorker extends Worker implements MethodChannel.MethodCallHa
                         log("Response with redirection code");
                         location = httpConn.getHeaderField("Location");
                         log("Location = " + location);
-                        base = new URL(fileURL);
+                        base = new URL(url);
                         next = new URL(base, location);  // Deal with relative URLs
                         url = next.toExternalForm();
                         log("New url: " + url);


### PR DESCRIPTION
### Problems
I have files that are redirect multiple url.
If it is redirect less than 2 times, everything works fine.
But if it is redirect more than 2 times, redirected url since the 3rd time will be incorrect.

### Root cause
`base` url we use was the original url (`fileUrl`) so at the 3rd time redirection which it should use the 2nd URL but it still use original URL.

### Solution
Use `url` instead of `fileUrl` when assigning to `base`