### PR TITLE
Ability to display alternative file name in notification on Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ final taskId = await FlutterDownloader.enqueue(
   savedDir: 'the path of directory where you want to save downloaded files',
   showNotification: true, // show download progress in status bar (for Android)
   openFileFromNotification: true, // click on notification to open downloaded file (for Android)
+  notificationFileName: 'Alternative file name', // show alternative file name in notification (for Android)
 );
 ````
 
@@ -318,6 +319,7 @@ CREATE TABLE `task` (
 	`headers`	TEXT,
 	`show_notification`	TINYINT DEFAULT 0,
 	`open_file_from_notification`	TINYINT DEFAULT 0,
+	`notification_file_name` TEXT,
 	`time_created`	INTEGER DEFAULT 0
 );
 ````

--- a/android/.idea/compiler.xml
+++ b/android/.idea/compiler.xml
@@ -4,5 +4,6 @@
     <annotationProcessing>
       <profile default="true" name="Default" enabled="true" />
     </annotationProcessing>
+    <bytecodeTargetLevel target="1.8" />
   </component>
 </project>

--- a/android/.idea/gradle.xml
+++ b/android/.idea/gradle.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="GradleMigrationSettings" migrationVersion="1" />
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
-        <compositeConfiguration>
-          <compositeBuild compositeDefinitionSource="SCRIPT" />
-        </compositeConfiguration>
+        <option name="testRunner" value="PLATFORM" />
         <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
         <option name="modules">
@@ -14,7 +13,7 @@
           </set>
         </option>
         <option name="resolveModulePerSourceSet" value="false" />
-        <option name="testRunner" value="PLATFORM" />
+        <option name="useQualifiedModuleNames" value="true" />
       </GradleProjectSettings>
     </option>
   </component>

--- a/android/.idea/misc.xml
+++ b/android/.idea/misc.xml
@@ -39,7 +39,7 @@
       </value>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" project-jdk-name="JDK" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="false" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/android/.idea/modules.xml
+++ b/android/.idea/modules.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="ProjectModuleManager">
-    <modules>
-      <module fileurl="file://$PROJECT_DIR$/flutter_downloader.iml" filepath="$PROJECT_DIR$/flutter_downloader.iml" />
-    </modules>
-  </component>
-</project>

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,5 @@
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-bin.zip
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/android/src/main/java/vn/hunghd/flutterdownloader/DownloadTask.java
+++ b/android/src/main/java/vn/hunghd/flutterdownloader/DownloadTask.java
@@ -13,10 +13,11 @@ public class DownloadTask {
     boolean resumable;
     boolean showNotification;
     boolean openFileFromNotification;
+    String notificationFilename;
     long timeCreated;
 
     DownloadTask(int primaryId, String taskId, int status, int progress, String url, String filename, String savedDir,
-                 String headers, String mimeType, boolean resumable, boolean showNotification, boolean openFileFromNotification, long timeCreated) {
+                 String headers, String mimeType, boolean resumable, boolean showNotification, boolean openFileFromNotification, String notificationFilename, long timeCreated) {
         this.primaryId = primaryId;
         this.taskId = taskId;
         this.status = status;
@@ -29,6 +30,7 @@ public class DownloadTask {
         this.resumable = resumable;
         this.showNotification = showNotification;
         this.openFileFromNotification = openFileFromNotification;
+        this.notificationFilename = notificationFilename;
         this.timeCreated = timeCreated;
     }
 

--- a/android/src/main/java/vn/hunghd/flutterdownloader/TaskContract.java
+++ b/android/src/main/java/vn/hunghd/flutterdownloader/TaskContract.java
@@ -19,6 +19,7 @@ public class TaskContract {
         public static final String COLUMN_NAME_HEADERS = "headers";
         public static final String COLUMN_NAME_SHOW_NOTIFICATION = "show_notification";
         public static final String COLUMN_NAME_OPEN_FILE_FROM_NOTIFICATION = "open_file_from_notification";
+        public static final String COLUMN_NAME_NOTIFICATION_FILE_NAME = "notification_file_name";
         public static final String COLUMN_NAME_TIME_CREATED = "time_created";
     }
 

--- a/android/src/main/java/vn/hunghd/flutterdownloader/TaskDao.java
+++ b/android/src/main/java/vn/hunghd/flutterdownloader/TaskDao.java
@@ -24,6 +24,7 @@ public class TaskDao {
             TaskContract.TaskEntry.COLUMN_NAME_RESUMABLE,
             TaskContract.TaskEntry.COLUMN_NAME_OPEN_FILE_FROM_NOTIFICATION,
             TaskContract.TaskEntry.COLUMN_NAME_SHOW_NOTIFICATION,
+            TaskContract.TaskEntry.COLUMN_NAME_NOTIFICATION_FILE_NAME,
             TaskContract.TaskEntry.COLUMN_NAME_TIME_CREATED
     };
 
@@ -32,7 +33,7 @@ public class TaskDao {
     }
 
     public void insertOrUpdateNewTask(String taskId, String url, int status, int progress, String fileName,
-                                       String savedDir, String headers, boolean showNotification, boolean openFileFromNotification) {
+                                       String savedDir, String headers, boolean showNotification, boolean openFileFromNotification, String notificationFileName) {
         SQLiteDatabase db = dbHelper.getWritableDatabase();
 
         ContentValues values = new ContentValues();
@@ -46,6 +47,7 @@ public class TaskDao {
         values.put(TaskContract.TaskEntry.COLUMN_NAME_MIME_TYPE, "unknown");
         values.put(TaskContract.TaskEntry.COLUMN_NAME_SHOW_NOTIFICATION, showNotification ? 1 : 0);
         values.put(TaskContract.TaskEntry.COLUMN_NAME_OPEN_FILE_FROM_NOTIFICATION, openFileFromNotification ? 1 : 0);
+        values.put(TaskContract.TaskEntry.COLUMN_NAME_NOTIFICATION_FILE_NAME, notificationFileName);
         values.put(TaskContract.TaskEntry.COLUMN_NAME_RESUMABLE, 0);
         values.put(TaskContract.TaskEntry.COLUMN_NAME_TIME_CREATED, System.currentTimeMillis());
 
@@ -221,10 +223,11 @@ public class TaskDao {
         String mimeType = cursor.getString(cursor.getColumnIndexOrThrow(TaskContract.TaskEntry.COLUMN_NAME_MIME_TYPE));
         int resumable = cursor.getShort(cursor.getColumnIndexOrThrow(TaskContract.TaskEntry.COLUMN_NAME_RESUMABLE));
         int showNotification = cursor.getShort(cursor.getColumnIndexOrThrow(TaskContract.TaskEntry.COLUMN_NAME_SHOW_NOTIFICATION));
+        String notificationFilename = cursor.getString(cursor.getColumnIndexOrThrow(TaskContract.TaskEntry.COLUMN_NAME_NOTIFICATION_FILE_NAME));
         int clickToOpenDownloadedFile = cursor.getShort(cursor.getColumnIndexOrThrow(TaskContract.TaskEntry.COLUMN_NAME_OPEN_FILE_FROM_NOTIFICATION));
         long timeCreated = cursor.getLong(cursor.getColumnIndexOrThrow(TaskContract.TaskEntry.COLUMN_NAME_TIME_CREATED));
         return new DownloadTask(primaryId, taskId, status, progress, url, filename, savedDir, headers,
-                mimeType, resumable == 1, showNotification == 1, clickToOpenDownloadedFile == 1, timeCreated);
+                mimeType, resumable == 1, showNotification == 1, clickToOpenDownloadedFile == 1, notificationFilename, timeCreated);
     }
 
 }

--- a/android/src/main/java/vn/hunghd/flutterdownloader/TaskDbHelper.java
+++ b/android/src/main/java/vn/hunghd/flutterdownloader/TaskDbHelper.java
@@ -7,7 +7,7 @@ import android.database.sqlite.SQLiteOpenHelper;
 import vn.hunghd.flutterdownloader.TaskContract.TaskEntry;
 
 public class TaskDbHelper extends SQLiteOpenHelper {
-    public static final int DATABASE_VERSION = 2;
+    public static final int DATABASE_VERSION = 3;
     public static final String DATABASE_NAME = "download_tasks.db";
 
     private static TaskDbHelper instance = null;
@@ -26,6 +26,7 @@ public class TaskDbHelper extends SQLiteOpenHelper {
                     TaskEntry.COLUMN_NAME_RESUMABLE + " TINYINT DEFAULT 0, " +
                     TaskEntry.COLUMN_NAME_SHOW_NOTIFICATION + " TINYINT DEFAULT 0, " +
                     TaskEntry.COLUMN_NAME_OPEN_FILE_FROM_NOTIFICATION + " TINYINT DEFAULT 0, " +
+                    TaskEntry.COLUMN_NAME_NOTIFICATION_FILE_NAME + " TEXT, " +
                     TaskEntry.COLUMN_NAME_TIME_CREATED + " INTEGER DEFAULT 0"
                     + ")";
 

--- a/lib/src/downloader.dart
+++ b/lib/src/downloader.dart
@@ -57,6 +57,9 @@ class FlutterDownloader {
   /// (only Android). If it is `true`, user can click on the notification to
   /// open and preview the downloaded file, otherwise, nothing happens. The
   /// default value is `true`
+  /// * `notificationFileName`: if `showNotification` is `true`, sets name
+  /// of downloaded file in notification (only Android). If this parameter
+  /// is not set, the plugin will apply value of `fileName` parameter
   ///
   /// **return:**
   ///
@@ -69,6 +72,7 @@ class FlutterDownloader {
       Map<String, String> headers,
       bool showNotification = true,
       bool openFileFromNotification = true,
+      String notificationFileName,
       bool requiresStorageNotLow = true}) async {
     assert(_initialized, 'FlutterDownloader.initialize() must be called first');
     assert(Directory(savedDir).existsSync());
@@ -90,6 +94,7 @@ class FlutterDownloader {
         'headers': headerBuilder.toString(),
         'show_notification': showNotification,
         'open_file_from_notification': openFileFromNotification,
+        'notification_file_name': notificationFileName,
         'requires_storage_not_low': requiresStorageNotLow,
       });
       return taskId;


### PR DESCRIPTION
I needed to display title of currently downloaded e-book in notification instead of displaying its file name (which is hash) or URL. This PR adds ability to set `notificationFileName` param to `FlutterDownloader.enqueue()`.
<img width="461" alt="Zrzut ekranu 2021-04-1 o 11 13 30" src="https://user-images.githubusercontent.com/5583015/113272083-8c0baa80-92db-11eb-923a-526bcf2ebb3c.png">
