### PR TITLE
fix getContentLength for Android < 7

### DIFF
--- a/android/src/main/java/vn/hunghd/flutterdownloader/DownloadWorker.java
+++ b/android/src/main/java/vn/hunghd/flutterdownloader/DownloadWorker.java
@@ -308,7 +308,7 @@ public class DownloadWorker extends Worker implements MethodChannel.MethodCallHa
 
             if ((responseCode == HttpURLConnection.HTTP_OK || (isResume && responseCode == HttpURLConnection.HTTP_PARTIAL)) && !isStopped()) {
                 String contentType = httpConn.getContentType();
-                long contentLength = httpConn.getContentLengthLong();
+                long contentLength = android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.N ? httpConn.getContentLengthLong() : httpConn.getContentLength();
                 log("Content-Type = " + contentType);
                 log("Content-Length = " + contentLength);
 


### PR DESCRIPTION
When the getContentLengthLong was implemented it started to break Android < 7 because this method does not exist!

This hotfix should be Merge ASAP as the plugin is not working on Android < 7.


This fixes  at least:

#458 #440 #434 