### PR TITLE
fix "only success task can be opened" bug

### DIFF
--- a/android/src/main/java/vn/hunghd/flutterdownloader/DownloadWorker.java
+++ b/android/src/main/java/vn/hunghd/flutterdownloader/DownloadWorker.java
@@ -386,8 +386,9 @@ public class DownloadWorker extends Worker implements MethodChannel.MethodCallHa
                         }
                     }
                 }
-                updateNotification(context, filename, status, progress, pendingIntent, true);
                 taskDao.updateTask(getId().toString(), status, progress);
+                updateNotification(context, filename, status, progress, pendingIntent, true);
+               
 
                 log(isStopped() ? "Download canceled" : "File downloaded");
             } else {


### PR DESCRIPTION
fix bug: when call  FlutterDownloader.open on downloadCallback,it will throw "only success task can be opened" exception, due to it "updateNotification " first then excute "taskDao.updateTask"