### PR TITLE
(Android) Add onStopped to cancel enqueued tasks earlier

### DIFF
--- a/android/src/main/java/vn/hunghd/flutterdownloader/DownloadWorker.java
+++ b/android/src/main/java/vn/hunghd/flutterdownloader/DownloadWorker.java
@@ -156,6 +156,22 @@ public class DownloadWorker extends Worker implements MethodChannel.MethodCallHa
         }
     }
 
+    @Override
+    public void onStopped() {
+        Context context = getApplicationContext();
+        dbHelper = TaskDbHelper.getInstance(context);
+        taskDao = new TaskDao(dbHelper);
+
+        String url = getInputData().getString(ARG_URL);
+        String filename = getInputData().getString(ARG_FILE_NAME);
+
+        DownloadTask task = taskDao.loadTask(getId().toString());
+        if (task.status == DownloadStatus.ENQUEUED) {
+            updateNotification(context, filename == null ? url : filename, DownloadStatus.CANCELED, -1, null, true);
+            taskDao.updateTask(getId().toString(), DownloadStatus.CANCELED, lastProgress);
+        }
+    }
+
     @NonNull
     @Override
     public Result doWork() {
@@ -178,12 +194,18 @@ public class DownloadWorker extends Worker implements MethodChannel.MethodCallHa
         msgPaused = res.getString(R.string.flutter_downloader_notification_paused);
         msgComplete = res.getString(R.string.flutter_downloader_notification_complete);
 
-        log("DownloadWorker{url=" + url + ",filename=" + filename + ",savedDir=" + savedDir + ",header=" + headers + ",isResume=" + isResume);
+        DownloadTask task = taskDao.loadTask(getId().toString());
+
+        log("DownloadWorker{url=" + url + ",filename=" + filename + ",savedDir=" + savedDir + ",header=" + headers + ",isResume=" + isResume + ",status=" + (task != null ? task.status : "GONE"));
+
+        // Task has been deleted or cancelled
+        if (task == null || task.status == DownloadStatus.CANCELED) {
+            return Result.success();
+        }
 
         showNotification = getInputData().getBoolean(ARG_SHOW_NOTIFICATION, false);
         clickToOpenDownloadedFile = getInputData().getBoolean(ARG_OPEN_FILE_FROM_NOTIFICATION, false);
 
-        DownloadTask task = taskDao.loadTask(getId().toString());
         primaryId = task.primaryId;
 
         setupNotification(context);


### PR DESCRIPTION
Android processes a limited number of worker threads at the same time. For enqueued tasks that get cancelled through `cancel`, it may take a long time for their status to change to `cancelled` and for the progress update to arrive.

This PR fixes it by leveraging the [`onStopped` callback](https://developer.android.com/reference/androidx/work/ListenableWorker#onStopped()) to cancel a task that is in the enqueued state immediately. Also, tasks that are cancelled (or even have been removed entirely) will not be processed in `doWork` anymore to avoid any further processing or exceptions.