### PR TITLE
Fix shortenSavedDirPath method iOS

### DIFF
--- a/ios/Classes/FlutterDownloaderPlugin.m
+++ b/ios/Classes/FlutterDownloaderPlugin.m
@@ -345,14 +345,17 @@ static BOOL debug = YES;
     if (debug) {
         NSLog(@"Absolute savedDir path: %@", absolutePath);
     }
+    
     if (absolutePath) {
         NSString* documentDirPath = [NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES) firstObject];
         NSRange foundRank = [absolutePath rangeOfString:documentDirPath];
         if (foundRank.length > 0) {
             // we increase the location of range by one because we want to remove the file separator as well.
-            return [absolutePath substringWithRange:NSMakeRange(foundRank.length + 1, absolutePath.length - documentDirPath.length - 1)];
+            NSString *shortenSavedDirPath = [absolutePath substringWithRange:NSMakeRange(foundRank.length + 1, absolutePath.length - documentDirPath.length - 1)];
+            return shortenSavedDirPath != nil ? shortenSavedDirPath : @"";
         }
     }
+   
     return absolutePath;
 }
 


### PR DESCRIPTION
fix shortenSavedDirPath method when substringWithRange return nil concatenated a null on the path and returned not found path.

Platform: IOS