### PR TITLE
fix callbackDispatcher not found issue in release mode for Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,12 +289,15 @@ void dispose() {
 	super.dispose();
 }
 
+@pragma('vm:entry-point')
 static void downloadCallback(String id, DownloadTaskStatus status, int progress) {
 	final SendPort send = IsolateNameServer.lookupPortByName('downloader_send_port');
 	send.send([id, status, progress]);
 }
 
 ````
+
+`@pragma('vm:entry-point')` must be placed above the `callback` function to avoid tree shaking in release mode for Android.
 
 
 #### Load all tasks:

--- a/lib/src/callback_dispatcher.dart
+++ b/lib/src/callback_dispatcher.dart
@@ -6,6 +6,9 @@ import 'package:flutter/widgets.dart';
 
 import 'models.dart';
 
+// pragma annotation is needed to avoid tree shaking in release mode
+// https://github.com/dart-lang/sdk/blob/master/runtime/docs/compiler/aot/entry_point_pragma.md
+@pragma('vm:entry-point')
 void callbackDispatcher() {
   const MethodChannel backgroundChannel =
       MethodChannel('vn.hunghd/downloader_background');


### PR DESCRIPTION
Need to add `@pragma('vm:entry-point')` to callbackDispatcher & custom callback for these to be triggered properly in release mode for Android. The issue only started happening after upgrading to flutter 2.10. 

This PR will fix this issue https://github.com/fluttercommunity/flutter_downloader/issues/614

For more info about pragma entry-point, check out:
https://github.com/dart-lang/sdk/blob/master/runtime/docs/compiler/aot/entry_point_pragma.md
https://github.com/flutter/flutter/wiki/Experimental:-Launch-Flutter-with-non-main-entrypoint#avoid-tree-shaking-in-release