### PR TITLE
fix: on iOS, check http status when downloaded finished

### DIFF
--- a/ios/Classes/FlutterDownloaderPlugin.m
+++ b/ios/Classes/FlutterDownloaderPlugin.m
@@ -876,54 +876,65 @@ static BOOL debug = YES;
 
 - (void)URLSession:(NSURLSession *)session downloadTask:(NSURLSessionDownloadTask *)downloadTask didFinishDownloadingToURL:(NSURL *)location
 {
+    
+    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) downloadTask.response;
+    long httpStatusCode = (long)[httpResponse statusCode];
+    
     if (debug) {
-        NSLog(@"URLSession:downloadTask:didFinishDownloadingToURL:");
+        NSLog(@"%s HTTP status code: %ld", __FUNCTION__, httpStatusCode);
     }
-
-    NSString *taskId = [self identifierForTask:downloadTask ofSession:session];
-    NSDictionary *task = [self loadTaskWithId:taskId];
-    NSURL *destinationURL = [self fileUrlOf:taskId taskInfo:task downloadTask:downloadTask];
-
-    [_runningTaskById removeObjectForKey:taskId];
-
-    NSError *error;
-    NSFileManager *fileManager = [NSFileManager defaultManager];
-
-    if ([fileManager fileExistsAtPath:[destinationURL path]]) {
-        [fileManager removeItemAtURL:destinationURL error:nil];
-    }
-
-    BOOL success = [fileManager copyItemAtURL:location
-                                        toURL:destinationURL
-                                        error:&error];
-
-    __typeof__(self) __weak weakSelf = self;
-    if (success) {
-        [self sendUpdateProgressForTaskId:taskId inStatus:@(STATUS_COMPLETE) andProgress:@100];
-        dispatch_sync(databaseQueue, ^{
-            [weakSelf updateTask:taskId status:STATUS_COMPLETE progress:100];
-        });
-    } else {
-        if (debug) {
-            NSLog(@"Unable to copy temp file. Error: %@", [error localizedDescription]);
+    
+    NSLog(@"%s HTTP status code: %ld", __FUNCTION__, httpStatusCode);
+    
+    bool isSuccess = (httpStatusCode >= 200 && httpStatusCode < 300);
+    
+    if (isSuccess) {
+        NSString *taskId = [self identifierForTask:downloadTask ofSession:session];
+        NSDictionary *task = [self loadTaskWithId:taskId];
+        NSURL *destinationURL = [self fileUrlOf:taskId taskInfo:task downloadTask:downloadTask];
+        
+        [_runningTaskById removeObjectForKey:taskId];
+        
+        NSError *error;
+        NSFileManager *fileManager = [NSFileManager defaultManager];
+        
+        if ([fileManager fileExistsAtPath:[destinationURL path]]) {
+            [fileManager removeItemAtURL:destinationURL error:nil];
         }
-        [self sendUpdateProgressForTaskId:taskId inStatus:@(STATUS_FAILED) andProgress:@(-1)];
-        dispatch_sync(databaseQueue, ^{
-            [weakSelf updateTask:taskId status:STATUS_FAILED progress:-1];
-        });
+        
+        BOOL success = [fileManager copyItemAtURL:location
+                                            toURL:destinationURL
+                                            error:&error];
+        
+        __typeof__(self) __weak weakSelf = self;
+        if (success) {
+            [self sendUpdateProgressForTaskId:taskId inStatus:@(STATUS_COMPLETE) andProgress:@100];
+            dispatch_sync(databaseQueue, ^{
+                [weakSelf updateTask:taskId status:STATUS_COMPLETE progress:100];
+            });
+        } else {
+            if (debug) {
+                NSLog(@"Unable to copy temp file. Error: %@", [error localizedDescription]);
+            }
+            [self sendUpdateProgressForTaskId:taskId inStatus:@(STATUS_FAILED) andProgress:@(-1)];
+            dispatch_sync(databaseQueue, ^{
+                [weakSelf updateTask:taskId status:STATUS_FAILED progress:-1];
+            });
+        }
     }
+    
 }
 
 -(void)URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task didCompleteWithError:(NSError *)error
 {
-    if (debug) {
-        NSLog(@"URLSession:task:didCompleteWithError:");
-    }
+    
     NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) task.response;
     long httpStatusCode = (long)[httpResponse statusCode];
+    
     if (debug) {
-        NSLog(@"HTTP status code: %ld", httpStatusCode);
+        NSLog(@"%s HTTP status code: %ld", __FUNCTION__, httpStatusCode);
     }
+    
     bool isSuccess = (httpStatusCode >= 200 && httpStatusCode < 300);
     if (error != nil || !isSuccess) {
         if (debug) {

--- a/ios/Classes/FlutterDownloaderPlugin.m
+++ b/ios/Classes/FlutterDownloaderPlugin.m
@@ -884,8 +884,6 @@ static BOOL debug = YES;
         NSLog(@"%s HTTP status code: %ld", __FUNCTION__, httpStatusCode);
     }
     
-    NSLog(@"%s HTTP status code: %ld", __FUNCTION__, httpStatusCode);
-    
     bool isSuccess = (httpStatusCode >= 200 && httpStatusCode < 300);
     
     if (isSuccess) {


### PR DESCRIPTION
Problem:

I observed that when downloading an `invalid` resource, it returns a success in [URLSession: downloadTask: didFinishDownloadingToURL:], then it returns a failure in [URLSession: task: didCompleteWithError:], finally callback twice. The expectation should be to only return a failure.

Why:

1. In [URLSession: downloadTask: didFinishDownloadingToURL:] , the http status code of the invalid resource's downloadTask is 404 or other failed code, and the location exists invalid temporary file which will be copied to the destinationURL. The copy result is succeeded, so it returns a success.

2. In [URLSession: task: didCompleteWithError:], invalid resource task status code is also 404 or other failed code, so it returns a failure.

Solution:

When 404  or other failed http status code appears, ignore it in [URLSession: downloadTask: didFinishDownloadingToURL:], but process it in [URLSession: task: didCompleteWithError:], ensure to only return a failure.