### PR TITLE
on iOS, bug fixed when deleting task concurrently

### DIFF
--- a/ios/Classes/FlutterDownloaderPlugin.m
+++ b/ios/Classes/FlutterDownloaderPlugin.m
@@ -765,7 +765,7 @@ static BOOL debug = YES;
             }];
         }
         
-        dispatch_sync([weakSelf databaseQueue], ^{
+        dispatch_sync([self databaseQueue], ^{
             [weakSelf deleteTask:taskId];
         });
         

--- a/ios/Classes/FlutterDownloaderPlugin.m
+++ b/ios/Classes/FlutterDownloaderPlugin.m
@@ -741,13 +741,14 @@ static BOOL debug = YES;
 }
 
 - (void)removeMethodCall:(FlutterMethodCall*)call result:(FlutterResult)result {
+    __typeof__(self) __weak weakSelf = self;
+
     NSString *taskId = call.arguments[KEY_TASK_ID];
     Boolean shouldDeleteContent = [call.arguments[@"should_delete_content"] boolValue];
     NSDictionary* taskDict = [self loadTaskWithId:taskId];
     if (taskDict != nil) {
         NSNumber* status = taskDict[KEY_STATUS];
         if ([status intValue] == STATUS_ENQUEUED || [status intValue] == STATUS_RUNNING) {
-            __typeof__(self) __weak weakSelf = self;
             [[self currentSession] getTasksWithCompletionHandler:^(NSArray<NSURLSessionDataTask *> *data, NSArray<NSURLSessionUploadTask *> *uploads, NSArray<NSURLSessionDownloadTask *> *downloads) {
                 for (NSURLSessionDownloadTask *download in downloads) {
                     NSURLSessionTaskState state = download.state;
@@ -763,7 +764,11 @@ static BOOL debug = YES;
                 };
             }];
         }
-        [self deleteTask:taskId];
+        
+        dispatch_sync([weakSelf databaseQueue], ^{
+            [weakSelf deleteTask:taskId];
+        });
+        
         if (shouldDeleteContent) {
             NSURL *destinationURL = [self fileUrlFromDict:taskDict];
 


### PR DESCRIPTION
On iOS, when a running or enqueued task is deleting，it may be executed concurrently on main thread and thread that database queue `vn.hunghd.flutter_downloader` dispatched，it may cause that `executeQueryResults` returns non `SQLITE_DONE(101)` in code ` int executeQueryResults = sqlite3_step(compiledStatement)`，finally, failed, the task is not removed from database actually.

For example, 12 tasks try to be removed in a for loop, but only 9 tasks are SQLITE_DONE.
<img width="1273" alt="screenshot" src="https://user-images.githubusercontent.com/66350348/168055117-7f8ec929-1614-44d5-9923-4972cd0660b7.png">
￼
I'm not sure if there's the case in other code, I haven't come across it yet.