### PR TITLE
Log only when `debug` is true + clean up documentation

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -3,7 +3,8 @@ name: flutter_downloader test
 on:
   push:
     branches: [master]
-    ignore-tags: ["flutter_downloader-v*"]
+    # don't run this workflow on version tags
+    ignore-tags: ["v*"]
   pull_request:
     branches: [master]
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,50 @@
+name: flutter_downloader test
+
+on:
+  push:
+    branches: [master]
+    ignore-tags: ["flutter_downloader-v*"]
+  pull_request:
+    branches: [master]
+
+jobs:
+  test:
+    name: Flutter ${{ matrix.channel }}${{ matrix.version }}
+
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - version: "2.5.0"
+          - channel: stable
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v1
+        with:
+          channel: ${{ matrix.channel }}
+          flutter-version: ${{ matrix.version }}
+
+      - name: Flutter version
+        run: flutter --version
+
+      - name: Cache pub dependencies
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.FLUTTER_HOME }}/.pub-cache
+          key: ${{ runner.os }}-pub-${{ hashFiles('**/pubspec.lock') }}
+          restore-keys: ${{ runner.os }}-pub-
+
+      - name: Download pub dependencies
+        run: flutter pub get
+
+      - name: Run analyzer
+        run: flutter analyze
+
+      - name: Dry run pub publish
+        # We don't want it to fail the CI, it's just to see how would `pub publish` behave.
+        run: dart pub publish --dry-run || true

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: package:flutter_lints/flutter.yaml

--- a/lib/flutter_downloader.dart
+++ b/lib/flutter_downloader.dart
@@ -1,17 +1,14 @@
+/// Provides the capability of creating and managing background download tasks.
+///
+/// This plugin depends on native APIs to run background tasks (WorkManager on
+/// Android and NSURLSessionDownloadTask on iOS).
+///
+/// All information about download tasks is saved in an SQLite databases. It
+/// gives a Flutter application benefit of either getting rid of managing task
+/// information manually or querying task data with SQL statements easily.
 ///
 /// * author: hunghd
 /// * email: hunghd.yb@gmail.com
-///
-/// A plugin provides the capability of creating and managing background download
-/// tasks. This plugin depends on native api to run background tasks, so these
-/// tasks aren't restricted by the limitation of Dart codes (in term of running
-/// background tasks out of scope of a Flutter application). Using native api
-/// also take benefit of memory and battery management.
-///
-/// All task information is saved in a Sqlite database, it gives a Flutter
-/// application benefit of either getting rid of managing task information
-/// manually or querying task data with SQL statements easily.
-///
 
 library flutter_downloader;
 

--- a/lib/flutter_downloader.dart
+++ b/lib/flutter_downloader.dart
@@ -3,7 +3,7 @@
 /// This plugin depends on native APIs to run background tasks (WorkManager on
 /// Android and NSURLSessionDownloadTask on iOS).
 ///
-/// All information about download tasks is saved in an SQLite databases. It
+/// All information about download tasks is saved in an SQLite database. It
 /// gives a Flutter application benefit of either getting rid of managing task
 /// information manually or querying task data with SQL statements easily.
 ///

--- a/lib/src/callback_dispatcher.dart
+++ b/lib/src/callback_dispatcher.dart
@@ -16,10 +16,9 @@ void callbackDispatcher() {
   WidgetsFlutterBinding.ensureInitialized();
 
   backgroundChannel.setMethodCallHandler((MethodCall call) async {
-    final List<dynamic> args = call.arguments;
+    final args = call.arguments;
     final handle = CallbackHandle.fromRawHandle(args[0]);
-    final Function? callback =
-        PluginUtilities.getCallbackFromHandle(handle);
+    final callback = PluginUtilities.getCallbackFromHandle(handle);
 
     if (callback == null) {
       print('Fatal: could not find callback');

--- a/lib/src/callback_dispatcher.dart
+++ b/lib/src/callback_dispatcher.dart
@@ -21,8 +21,9 @@ void callbackDispatcher() {
     final callback = PluginUtilities.getCallbackFromHandle(handle);
 
     if (callback == null) {
-      print('Fatal: could not find callback');
-      exit(-1);
+      // ignore: avoid_print
+      print('fatal error: could not find callback');
+      exit(1);
     }
 
     final String id = args[1];

--- a/lib/src/downloader.dart
+++ b/lib/src/downloader.dart
@@ -250,7 +250,7 @@ class FlutterDownloader {
     required String taskId,
     bool requiresStorageNotLow = true,
   }) async {
-    assert(_initialized, 'FlutterDownloader.initialize() must be called first');
+    assert(_initialized, 'plugin flutter_downloader is not initialized');
 
     try {
       return await _channel.invokeMethod('retry', {

--- a/lib/src/downloader.dart
+++ b/lib/src/downloader.dart
@@ -8,22 +8,19 @@ import 'package:flutter/widgets.dart';
 import 'callback_dispatcher.dart';
 import 'models.dart';
 
-/// A signature function for download progress updating callback
-///
-/// * `id`: unique identifier of a download task
-/// * `status`: current status of a download task
-/// * `progress`: current progress value of a download task, the value is in
-///   range of 0 and 100
-///
+/// Singature for a function which gets called when the download status changes.
 typedef DownloadCallback = void Function(
+  /// Unique identifier of a download task
   String id,
+
+  /// Current status of a download task
   DownloadTaskStatus status,
+
+  /// Current progress value of a download task, the value is in range <0, 100>.
   int progress,
 );
 
-///
-/// A convenient class wraps all api functions of **FlutterDownloader** plugin
-///
+/// Provides access to all functions of the plugin in a single place.
 class FlutterDownloader {
   static const _channel = MethodChannel('vn.hunghd/downloader');
   static bool _initialized = false;
@@ -73,15 +70,16 @@ class FlutterDownloader {
   ///
   /// a unique identifier of the new download task
   ///
-  static Future<String?> enqueue(
-      {required String url,
-      required String savedDir,
-      String? fileName,
-      Map<String, String>? headers,
-      bool showNotification = true,
-      bool openFileFromNotification = true,
-      bool requiresStorageNotLow = true,
-      bool saveInPublicStorage = false}) async {
+  static Future<String?> enqueue({
+    required String url,
+    required String savedDir,
+    String? fileName,
+    Map<String, String>? headers,
+    bool showNotification = true,
+    bool openFileFromNotification = true,
+    bool requiresStorageNotLow = true,
+    bool saveInPublicStorage = false,
+  }) async {
     assert(_initialized, 'FlutterDownloader.initialize() must be called first');
     assert(Directory(savedDir).existsSync());
 
@@ -149,7 +147,6 @@ class FlutterDownloader {
   ///   query: 'SELECT * FROM task WHERE status=3',
   /// );
   /// ```
-  ///
   static Future<List<DownloadTask>?> loadTasksWithRawQuery({
     required String query,
   }) async {
@@ -232,8 +229,7 @@ class FlutterDownloader {
     }
   }
 
-  ///
-  /// Retry a failed download task
+  /// Retries a failed download task.
   ///
   /// **parameters:**
   ///
@@ -243,7 +239,6 @@ class FlutterDownloader {
   ///
   /// An unique identifier of a new download task that is created to start the
   /// failed download progress from the beginning
-  ///
   static Future<String?> retry({
     required String taskId,
     bool requiresStorageNotLow = true,
@@ -261,9 +256,8 @@ class FlutterDownloader {
     }
   }
 
-  ///
-  /// Delete a download task from DB. If the given task is running, it is
-  /// canceled as well. If the task is completed and `shouldDeleteContent` is
+  /// Deletes a download task from the database. If the given task is running,
+  /// it is also canceled. If the task is completed and `shouldDeleteContent` is
   /// `true`, the downloaded file will be deleted.
   ///
   /// **parameters:**
@@ -271,9 +265,10 @@ class FlutterDownloader {
   /// * `taskId`: unique identifier of a download task
   /// * `shouldDeleteContent`: if the task is completed, set `true` to let the
   ///   plugin remove the downloaded file. The default value is `false`.
-  ///
-  static Future<void> remove(
-      {required String taskId, bool shouldDeleteContent = false}) async {
+  static Future<void> remove({
+    required String taskId,
+    bool shouldDeleteContent = false,
+  }) async {
     assert(_initialized, 'FlutterDownloader.initialize() must be called first');
 
     try {
@@ -285,8 +280,7 @@ class FlutterDownloader {
     }
   }
 
-  ///
-  /// Open and preview a downloaded file
+  /// Opens and preview a downloaded file
   ///
   /// **parameters:**
   ///
@@ -299,13 +293,12 @@ class FlutterDownloader {
   ///
   /// **Note:**
   ///
-  /// In Android case, there're two requirements in order to be able to open a
+  /// In Android case, there are two requirements in order to be able to open a
   /// file:
   /// - The file have to be saved in external storage where other applications
   ///   have permission to read this file
-  /// - The current device has at least an application that can read the file
+  /// - The current device has at least 1 application that can read the file
   ///   type of the file
-  ///
   static Future<bool> open({required String taskId}) async {
     assert(_initialized, 'FlutterDownloader.initialize() must be called first');
 

--- a/lib/src/downloader.dart
+++ b/lib/src/downloader.dart
@@ -8,7 +8,7 @@ import 'package:flutter/widgets.dart';
 import 'callback_dispatcher.dart';
 import 'models.dart';
 
-/// Singature for a function which gets called when the download state of a task
+/// Singature for a function which is called when the download state of a task
 /// with [id] changes.
 typedef DownloadCallback = void Function(
   String id,
@@ -20,19 +20,35 @@ typedef DownloadCallback = void Function(
 class FlutterDownloader {
   static const _channel = MethodChannel('vn.hunghd/downloader');
   static bool _initialized = false;
+  static bool _debug = false;
 
+  /// Initializes the plugin. This must be called before any other method.
+  ///
+  /// Pass true for [debug] if you want to see debug logs in the console.
+  ///
+  /// To ignore SSL-related errors on Android, set [ignoreSsl] to true. This may
+  /// be useful when connecting to a test server which is not using SSL, but
+  /// should be never used in production.
   static Future<void> initialize({
     bool debug = true,
     bool ignoreSsl = false,
   }) async {
-    assert(!_initialized,
-        'FlutterDownloader.initialize() must be called only once!');
+    assert(
+      !_initialized,
+      'plugin flutter_downloader has already been initialized',
+    );
+
+    _debug = debug;
 
     WidgetsFlutterBinding.ensureInitialized();
 
     final callback = PluginUtilities.getCallbackHandle(callbackDispatcher)!;
-    await _channel.invokeMethod('initialize',
-        <dynamic>[callback.toRawHandle(), debug ? 1 : 0, ignoreSsl ? 1 : 0]);
+    await _channel.invokeMethod('initialize', <dynamic>[
+      callback.toRawHandle(),
+      debug ? 1 : 0,
+      ignoreSsl ? 1 : 0,
+    ]);
+
     _initialized = true;
   }
 
@@ -73,8 +89,8 @@ class FlutterDownloader {
     bool requiresStorageNotLow = true,
     bool saveInPublicStorage = false,
   }) async {
-    assert(_initialized, 'FlutterDownloader.initialize() must be called first');
-    assert(Directory(savedDir).existsSync());
+    assert(_initialized, 'plugin flutter_downloader is not initialized');
+    assert(Directory(savedDir).existsSync(), "savedDir does not exist");
 
     StringBuffer headerBuilder = StringBuffer();
     if (headers != null) {
@@ -98,14 +114,14 @@ class FlutterDownloader {
       });
       return taskId;
     } on PlatformException catch (e) {
-      print('Download task is failed with reason(${e.message})');
+      _log('Download task is failed with reason(${e.message})');
       return null;
     }
   }
 
   /// Loads all tasks from SQLite database.
   static Future<List<DownloadTask>?> loadTasks() async {
-    assert(_initialized, 'FlutterDownloader.initialize() must be called first');
+    assert(_initialized, 'plugin flutter_downloader is not initialized');
 
     try {
       List<dynamic> result = await _channel.invokeMethod('loadTasks');
@@ -120,7 +136,7 @@ class FlutterDownloader {
               timeCreated: item['time_created']))
           .toList();
     } on PlatformException catch (e) {
-      print(e.message);
+      _log(e.message);
       return null;
     }
   }
@@ -144,7 +160,7 @@ class FlutterDownloader {
   static Future<List<DownloadTask>?> loadTasksWithRawQuery({
     required String query,
   }) async {
-    assert(_initialized, 'FlutterDownloader.initialize() must be called first');
+    assert(_initialized, 'plugin flutter_downloader is not initialized');
 
     try {
       List<dynamic> result = await _channel
@@ -160,45 +176,42 @@ class FlutterDownloader {
               timeCreated: item['time_created']))
           .toList();
     } on PlatformException catch (e) {
-      print(e.message);
+      _log(e.message);
       return null;
     }
   }
 
   /// Cancels download task with id [taskId].
   static Future<void> cancel({required String taskId}) async {
-    assert(_initialized, 'FlutterDownloader.initialize() must be called first');
+    assert(_initialized, 'plugin flutter_downloader is not initialized');
 
     try {
       return await _channel.invokeMethod('cancel', {'task_id': taskId});
     } on PlatformException catch (e) {
-      print(e.message);
-      return;
+      _log(e.message);
     }
   }
 
   /// Cancels all enqueued and running download tasks.
   static Future<void> cancelAll() async {
-    assert(_initialized, 'FlutterDownloader.initialize() must be called first');
+    assert(_initialized, 'plugin flutter_downloader is not initialized');
 
     try {
       return await _channel.invokeMethod('cancelAll');
     } on PlatformException catch (e) {
-      print(e.message);
-      return;
+      _log(e.message);
     }
   }
 
   /// Pauses a running download task with id [taskId].
   ///
   static Future<void> pause({required String taskId}) async {
-    assert(_initialized, 'FlutterDownloader.initialize() must be called first');
+    assert(_initialized, 'plugin flutter_downloader is not initialized');
 
     try {
       return await _channel.invokeMethod('pause', {'task_id': taskId});
     } on PlatformException catch (e) {
-      print(e.message);
-      return;
+      _log(e.message);
     }
   }
 
@@ -210,7 +223,7 @@ class FlutterDownloader {
     required String taskId,
     bool requiresStorageNotLow = true,
   }) async {
-    assert(_initialized, 'FlutterDownloader.initialize() must be called first');
+    assert(_initialized, 'plugin flutter_downloader is not initialized');
 
     try {
       return await _channel.invokeMethod('resume', {
@@ -218,7 +231,7 @@ class FlutterDownloader {
         'requires_storage_not_low': requiresStorageNotLow,
       });
     } on PlatformException catch (e) {
-      print(e.message);
+      _log(e.message);
       return null;
     }
   }
@@ -245,7 +258,7 @@ class FlutterDownloader {
         'requires_storage_not_low': requiresStorageNotLow,
       });
     } on PlatformException catch (e) {
-      print(e.message);
+      _log(e.message);
       return null;
     }
   }
@@ -263,14 +276,15 @@ class FlutterDownloader {
     required String taskId,
     bool shouldDeleteContent = false,
   }) async {
-    assert(_initialized, 'FlutterDownloader.initialize() must be called first');
+    assert(_initialized, 'plugin flutter_downloader is not initialized');
 
     try {
-      return await _channel.invokeMethod('remove',
-          {'task_id': taskId, 'should_delete_content': shouldDeleteContent});
+      return await _channel.invokeMethod('remove', {
+        'task_id': taskId,
+        'should_delete_content': shouldDeleteContent,
+      });
     } on PlatformException catch (e) {
-      print(e.message);
-      return;
+      _log(e.message);
     }
   }
 
@@ -283,12 +297,12 @@ class FlutterDownloader {
   /// - There is at least 1 application that can read the files of type of the
   ///   file.
   static Future<bool> open({required String taskId}) async {
-    assert(_initialized, 'FlutterDownloader.initialize() must be called first');
+    assert(_initialized, 'plugin flutter_downloader is not initialized');
 
     try {
       return await _channel.invokeMethod('open', {'task_id': taskId});
     } on PlatformException catch (e) {
-      print(e.message);
+      _log(e.message);
       return false;
     }
   }
@@ -347,12 +361,20 @@ class FlutterDownloader {
   ///
   /// {@end-tool}
   static registerCallback(DownloadCallback callback) {
-    assert(_initialized, 'FlutterDownloader.initialize() must be called first');
+    assert(_initialized, 'plugin flutter_downloader is not initialized');
 
     final callbackHandle = PluginUtilities.getCallbackHandle(callback)!;
     _channel.invokeMethod(
       'registerCallback',
       <dynamic>[callbackHandle.toRawHandle()],
     );
+  }
+
+  /// Prints [message] to console if [_debug] is true.
+  static void _log(String? message) {
+    if (_debug) {
+      // ignore: avoid_print
+      print(message);
+    }
   }
 }

--- a/lib/src/models.dart
+++ b/lib/src/models.dart
@@ -17,10 +17,10 @@ class DownloadTaskStatus {
   static const paused = DownloadTaskStatus(6);
 
   @override
-  bool operator ==(Object o) {
-    if (identical(this, o)) return true;
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
 
-    return o is DownloadTaskStatus && o._value == _value;
+    return other is DownloadTaskStatus && other._value == _value;
   }
 
   @override
@@ -30,34 +30,40 @@ class DownloadTaskStatus {
   String toString() => 'DownloadTaskStatus($_value)';
 }
 
-/// A model class encapsulates all task information according to data in Sqlite
-/// database.
+/// Encapsulates all information of a single download task.
 ///
-/// * [taskId] the unique identifier of a download task
-/// * [status] the latest status of a download task
-/// * [progress] the latest progress value of a download task
-/// * [url] the download link
-/// * [filename] the local file name of a downloaded file
-/// * [savedDir] the absolute path of the directory where the downloaded file is saved
-/// * [timeCreated] milliseconds since the Unix epoch (midnight, January 1, 1970 UTC)
-///
+/// This is also the structure of the record saved in the SQLite database.
 class DownloadTask {
+  /// Unique identifier of this task.
   final String taskId;
+
+  /// Status of this task.
   final DownloadTaskStatus status;
+
+  /// Progress between 0 (inclusive) and 100 (inclusive).
   final int progress;
+
+  /// URL from which the file is downloaded.
   final String url;
+
+  /// Local file name of the downloaded file.
   final String? filename;
+
+  /// Absolute path to the directory where the downloaded file will saved.
   final String savedDir;
+
+  /// Timestamp when the task was created.
   final int timeCreated;
 
-  DownloadTask(
-      {required this.taskId,
-      required this.status,
-      required this.progress,
-      required this.url,
-      required this.filename,
-      required this.savedDir,
-      required this.timeCreated});
+  DownloadTask({
+    required this.taskId,
+    required this.status,
+    required this.progress,
+    required this.url,
+    required this.filename,
+    required this.savedDir,
+    required this.timeCreated,
+  });
 
   @override
   String toString() =>

--- a/lib/src/models.dart
+++ b/lib/src/models.dart
@@ -1,6 +1,4 @@
-///
-/// A class defines a set of possible statuses of a download task
-///
+/// Defines a set of possible statuses of a download task.
 class DownloadTaskStatus {
   final int _value;
 
@@ -10,13 +8,13 @@ class DownloadTaskStatus {
 
   static DownloadTaskStatus from(int value) => DownloadTaskStatus(value);
 
-  static const undefined = const DownloadTaskStatus(0);
-  static const enqueued = const DownloadTaskStatus(1);
-  static const running = const DownloadTaskStatus(2);
-  static const complete = const DownloadTaskStatus(3);
-  static const failed = const DownloadTaskStatus(4);
-  static const canceled = const DownloadTaskStatus(5);
-  static const paused = const DownloadTaskStatus(6);
+  static const undefined = DownloadTaskStatus(0);
+  static const enqueued = DownloadTaskStatus(1);
+  static const running = DownloadTaskStatus(2);
+  static const complete = DownloadTaskStatus(3);
+  static const failed = DownloadTaskStatus(4);
+  static const canceled = DownloadTaskStatus(5);
+  static const paused = DownloadTaskStatus(6);
 
   @override
   bool operator ==(Object o) {
@@ -32,7 +30,6 @@ class DownloadTaskStatus {
   String toString() => 'DownloadTaskStatus($_value)';
 }
 
-///
 /// A model class encapsulates all task information according to data in Sqlite
 /// database.
 ///

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,13 +14,14 @@ flutter:
         pluginClass: FlutterDownloaderPlugin
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
-  flutter: '>=1.20.0'
+  sdk: ">=2.12.0 <3.0.0"
+  flutter: ">=1.20.0"
 
 dependencies:
   flutter:
     sdk: flutter
 
 dev_dependencies:
+  flutter_lints: ^2.0.1
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
A bunch of smaller refactors

- formatted all code using `flutter format`
- added linting using [flutter_lints](https://pub.dev/packages/flutter_lints)
- added a GitHub Action which runs `flutter format` and `flutter analyze` for Pull Requests. This will require new code to conform to a single style

- if `FlutterDownloader.initialize(debug: false)` is called, then no logs will be printed to the console (at least on the Dart side).

I also rewrote most of the docs. I strived for conformance with [Effective Dart guide](https://dart.dev/guides/language/effective-dart/documentation).

@hnvn, please review if you have some free time :)