### PR TITLE
fix: On iOS, update task concurrently as terminating caused failed of the operation to tag canceled

### DIFF
--- a/ios/Classes/FlutterDownloaderPlugin.m
+++ b/ios/Classes/FlutterDownloaderPlugin.m
@@ -847,7 +847,10 @@ static BOOL debug = YES;
     }
     for (NSString* key in _runningTaskById) {
         if ([_runningTaskById[key][KEY_STATUS] intValue] < STATUS_COMPLETE) {
-            [self updateTask:key status:STATUS_CANCELED progress:-1];
+            __typeof__(self) __weak weakSelf = self;
+            dispatch_sync(databaseQueue, ^{
+                [weakSelf updateTask:key status:STATUS_CANCELED progress:-1];
+            });
         }
     }
     _session = nil;


### PR DESCRIPTION
On iOS, Update concurrently as terminating caused exceptional results:

1. The operation to tag canceled failed.
2. The task can't continue when the process restarted automatically or manually.

Its reason is same as https://github.com/fluttercommunity/flutter_downloader/pull/637.