### PR TITLE
Add SQLite migration from version 2 to 3

### DIFF
--- a/android/src/main/java/vn/hunghd/flutterdownloader/TaskDbHelper.java
+++ b/android/src/main/java/vn/hunghd/flutterdownloader/TaskDbHelper.java
@@ -57,8 +57,12 @@ public class TaskDbHelper extends SQLiteOpenHelper {
 
     @Override
     public void onUpgrade(SQLiteDatabase db, int oldVersion, int newVersion) {
-        db.execSQL(SQL_DELETE_ENTRIES);
-        onCreate(db);
+        if (oldVersion == 2 && newVersion == 3) {
+            db.execSQL("ALTER TABLE " + TaskEntry.TABLE_NAME + " ADD COLUMN " + TaskEntry.COLUMN_SAVE_IN_PUBLIC_STORAGE + " TINYINT DEFAULT 0";
+        } else {
+            db.execSQL(SQL_DELETE_ENTRIES);
+            onCreate(db);
+        }
     }
 
     @Override

--- a/android/src/main/java/vn/hunghd/flutterdownloader/TaskDbHelper.java
+++ b/android/src/main/java/vn/hunghd/flutterdownloader/TaskDbHelper.java
@@ -58,7 +58,7 @@ public class TaskDbHelper extends SQLiteOpenHelper {
     @Override
     public void onUpgrade(SQLiteDatabase db, int oldVersion, int newVersion) {
         if (oldVersion == 2 && newVersion == 3) {
-            db.execSQL("ALTER TABLE " + TaskEntry.TABLE_NAME + " ADD COLUMN " + TaskEntry.COLUMN_SAVE_IN_PUBLIC_STORAGE + " TINYINT DEFAULT 0";
+            db.execSQL("ALTER TABLE " + TaskEntry.TABLE_NAME + " ADD COLUMN " + TaskEntry.COLUMN_SAVE_IN_PUBLIC_STORAGE + " TINYINT DEFAULT 0");
         } else {
             db.execSQL(SQL_DELETE_ENTRIES);
             onCreate(db);


### PR DESCRIPTION
Currently, the database is just deleted when migrating. This can be pretty confusing when upgrading flutter_downloader, and may cause issues in apps that depend on the database always being there. This PR adds a simple migration from version 2 to 3 so that the database is upgraded instead of deleted.