### PR TITLE
chore(readme): add header parameter to enqueue function

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,7 @@ void main() {
 ```dart
 final taskId = await FlutterDownloader.enqueue(
   url: 'your download link',
+  headers: {}, // optional: header send with url (auth token etc)
   savedDir: 'the path of directory where you want to save downloaded files',
   showNotification: true, // show download progress in status bar (for Android)
   openFileFromNotification: true, // click on notification to open downloaded file (for Android)


### PR DESCRIPTION
I wish someone included this in the readme earlier. My flutter guy was saying it wasn't possible to pass auth token with the download URL and I had to dig up the code to check if it was possible. And viola!

P.S I have no understanding of flutter/dart.