### PR TITLE
Add vm-entry to model

### DIFF
--- a/lib/src/models.dart
+++ b/lib/src/models.dart
@@ -1,4 +1,5 @@
 /// Defines a set of possible statuses of a download task.
+@pragma('vm:entry-point')
 class DownloadTaskStatus {
   final int _value;
 


### PR DESCRIPTION
As discussed in https://github.com/flutter/flutter/issues/109248

this fixes #698 

As the app crashes on release mode in flutter 3.3+  and it is not a breaking change i suggest releasing a new version ASAP

