### PR TITLE
fix `FlutterDownloader.open()` always returning false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.8.4
+
+- Fix `FlutterDownloader.open()` always returning false (#726)
+
 ## 1.8.3+2
 
 - Populate `issue_tracker` field in pubspec (#717)

--- a/lib/src/downloader.dart
+++ b/lib/src/downloader.dart
@@ -340,8 +340,9 @@ class FlutterDownloader {
   static Future<bool> open({required String taskId}) async {
     assert(_initialized, 'plugin flutter_downloader is not initialized');
 
+    bool? result;
     try {
-      final result = await _channel.invokeMethod<bool>(
+      result = await _channel.invokeMethod<bool>(
         'open',
         {'task_id': taskId},
       );
@@ -351,10 +352,9 @@ class FlutterDownloader {
       }
     } on PlatformException catch (err) {
       _log('Failed to open downloaded file. Reason: ${err.message}');
-      return false;
     }
 
-    return false;
+    return result ?? false;
   }
 
   /// Registers a [callback] to track the status and progress of a download

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_downloader
 description: Powerful plugin making it easy to download files.
-version: 1.8.3+2
+version: 1.8.4
 repository: https://github.com/fluttercommunity/flutter_downloader
 issue_tracker: https://github.com/fluttercommunity/flutter_downloader/issues
 maintainer: Bartek Pacia (@bartekpacia)


### PR DESCRIPTION
fix #725