### PR TITLE
fix: android wrong last progress due to missing initial value

### DIFF
--- a/android/src/main/kotlin/vn/hunghd/flutterdownloader/DownloadWorker.kt
+++ b/android/src/main/kotlin/vn/hunghd/flutterdownloader/DownloadWorker.kt
@@ -278,7 +278,9 @@ class DownloadWorker(context: Context, params: WorkerParameters) :
         visited = HashMap()
         try {
             val task = taskDao?.loadTask(id.toString())
-            if (task != null) lastProgress = task.progress;
+            if (task != null) {
+                lastProgress = task.progress
+            }
 
             // handle redirection logic
             while (true) {

--- a/android/src/main/kotlin/vn/hunghd/flutterdownloader/DownloadWorker.kt
+++ b/android/src/main/kotlin/vn/hunghd/flutterdownloader/DownloadWorker.kt
@@ -277,6 +277,9 @@ class DownloadWorker(context: Context, params: WorkerParameters) :
         var timeout = timeout
         visited = HashMap()
         try {
+            val task = taskDao?.loadTask(id.toString())
+            if (task != null) lastProgress = task.progress;
+
             // handle redirection logic
             while (true) {
                 if (!visited.containsKey(url)) {


### PR DESCRIPTION
# wrong last progress

<img width="1163" alt="r" src="https://user-images.githubusercontent.com/66350348/200491871-10a88183-deb2-4b36-a032-77778950be5c.png">

If `if clause(if ((responseCode...)` was never executed, the `lastProgress` is always `0`. It will storage a wrong progress(`0`). So `lastProgress` needs assign the real initial value to avoid the `0-case`.

In fact, this happened indeed when I was developing. While I switch action such as pause/resume frequently in poor network, the progress will flash between `0` and real progress on the UI.

For further reason, `isStopped` is always `true` so that `if clause(if ((responseCode...)` was never executed. I guess that it's due to workers over the limit.