### PR TITLE
Clean up example app code

### DIFF
--- a/android/src/main/kotlin/vn/hunghd/flutterdownloader/IntentUtils.kt
+++ b/android/src/main/kotlin/vn/hunghd/flutterdownloader/IntentUtils.kt
@@ -34,7 +34,7 @@ object IntentUtils {
     fun validatedFileIntent(context: Context, path: String, contentType: String?): Intent? {
         val file = File(path)
         var intent = buildIntent(context, file, contentType)
-        if (validateIntent(context, intent)) {
+        if (canBeHandled(context, intent)) {
             return intent
         }
         var mime: String? = null
@@ -58,15 +58,15 @@ object IntentUtils {
         }
         if (mime != null) {
             intent = buildIntent(context, file, mime)
-            if (validateIntent(context, intent)) return intent
+            if (canBeHandled(context, intent)) return intent
         }
         return null
     }
 
-    private fun validateIntent(context: Context, intent: Intent): Boolean {
+    private fun canBeHandled(context: Context, intent: Intent): Boolean {
         val manager = context.packageManager
         val results = manager.queryIntentActivities(intent, 0)
-        // Valid if there is at least one app that can handle this intent
+        // return if there is at least one app that can handle this intent
         return results.size > 0
     }
 }

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -10,7 +10,6 @@
         android:name="${applicationName}"
         android:label="Flutter Downloader"
         android:usesCleartextTraffic="true"
-        android:requestLegacyExternalStorage="true"
         android:icon="@mipmap/ic_launcher">
         <activity
             android:name=".MainActivity"

--- a/example/lib/home_page.dart
+++ b/example/lib/home_page.dart
@@ -111,61 +111,61 @@ class _MyHomePageState extends State<MyHomePage> {
             Checkbox(
               value: _saveInPublicStorage,
               onChanged: (newValue) {
-                setState(() {
-                  _saveInPublicStorage = newValue ?? false;
-                  print('_saveInPublicStorage: $_saveInPublicStorage');
-                });
+                setState(() => _saveInPublicStorage = newValue ?? false);
               },
             ),
             const Text('Save in public storage'),
           ],
         ),
-        for (final item in _items)
-          item.task == null
-              ? _buildListSectionHeading(item.name!)
-              : DownloadListItem(
-                  data: item,
-                  onTap: (task) async {
-                    final success = await _openDownloadedFile(task);
-                    if (!success) {
-                      ScaffoldMessenger.of(context).showSnackBar(
-                        const SnackBar(
-                          content: Text('Cannot open this file'),
-                        ),
-                      );
-                    }
-                  },
-                  onActionTap: (task) {
-                    if (task.status == DownloadTaskStatus.undefined) {
-                      _requestDownload(task);
-                    } else if (task.status == DownloadTaskStatus.running) {
-                      _pauseDownload(task);
-                    } else if (task.status == DownloadTaskStatus.paused) {
-                      _resumeDownload(task);
-                    } else if (task.status == DownloadTaskStatus.complete ||
-                        task.status == DownloadTaskStatus.canceled) {
-                      _delete(task);
-                    } else if (task.status == DownloadTaskStatus.failed) {
-                      _retryDownload(task);
-                    }
-                  },
-                  onCancel: _delete,
+        ..._items.map(
+          (item) {
+            final task = item.task;
+            if (task == null) {
+              return Container(
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                child: Text(
+                  item.name!,
+                  style: const TextStyle(
+                    fontWeight: FontWeight.bold,
+                    color: Colors.blue,
+                    fontSize: 18,
+                  ),
                 ),
-      ],
-    );
-  }
+              );
+            }
 
-  Widget _buildListSectionHeading(String title) {
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-      child: Text(
-        title,
-        style: const TextStyle(
-          fontWeight: FontWeight.bold,
-          color: Colors.blue,
-          fontSize: 18,
+            return DownloadListItem(
+              data: item,
+              onTap: (task) async {
+                final success = await _openDownloadedFile(task);
+                if (!success) {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(
+                      content: Text('Cannot open this file'),
+                    ),
+                  );
+                }
+              },
+              onActionTap: (task) {
+                if (task.status == DownloadTaskStatus.undefined) {
+                  _requestDownload(task);
+                } else if (task.status == DownloadTaskStatus.running) {
+                  _pauseDownload(task);
+                } else if (task.status == DownloadTaskStatus.paused) {
+                  _resumeDownload(task);
+                } else if (task.status == DownloadTaskStatus.complete ||
+                    task.status == DownloadTaskStatus.canceled) {
+                  _delete(task);
+                } else if (task.status == DownloadTaskStatus.failed) {
+                  _retryDownload(task);
+                }
+              },
+              onCancel: _delete,
+            );
+          },
         ),
-      ),
+      ],
     );
   }
 
@@ -216,7 +216,7 @@ class _MyHomePageState extends State<MyHomePage> {
       url: task.link!,
       headers: {'auth': 'test_for_sql_encoding'},
       savedDir: _localPath,
-      saveInPublicStorage: true,
+      saveInPublicStorage: _saveInPublicStorage,
     );
   }
 
@@ -234,10 +234,10 @@ class _MyHomePageState extends State<MyHomePage> {
     task.taskId = newTaskId;
   }
 
-  Future<bool> _openDownloadedFile(TaskInfo? task) {
+  Future<bool> _openDownloadedFile(TaskInfo? task) async {
     final taskId = task?.taskId;
     if (taskId == null) {
-      return Future.value(false);
+      return false;
     }
 
     return FlutterDownloader.open(taskId: taskId);

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   android_path_provider: ^0.3.0
-  device_info: ^2.0.3
+  device_info_plus: ^8.0.0
   flutter:
     sdk: flutter
   flutter_downloader:


### PR DESCRIPTION
- example app: simplify permission code
- code refactors
- remove not-needed requestLegacyExternalStorage from Manifest
- add "save to public storage" checkbox to example app
- clean up example app home page code
