### PR TITLE
Correctly read the error/success codes

### DIFF
--- a/ios/Classes/DBManager.m
+++ b/ios/Classes/DBManager.m
@@ -97,7 +97,13 @@
     
     
     // Open the database.
-    BOOL openDatabaseResult = sqlite3_open([databasePath UTF8String], &sqlite3Database);
+    int openDatabaseResult = sqlite3_open([databasePath UTF8String], &sqlite3Database);
+    if(openDatabaseResult != SQLITE_OK) {
+        if(debug) {
+            NSLog(@"error opening the database with error no.: %d", openDatabaseResult);
+        }
+        return;
+    }
     if(openDatabaseResult == SQLITE_OK) {
         if (debug) {
             NSLog(@"open DB successfully");
@@ -107,7 +113,7 @@
         sqlite3_stmt *compiledStatement;
 
         // Load all data from database to memory.
-        BOOL prepareStatementResult = sqlite3_prepare_v2(sqlite3Database, query, -1, &compiledStatement, NULL);
+        int prepareStatementResult = sqlite3_prepare_v2(sqlite3Database, query, -1, &compiledStatement, NULL);
         if(prepareStatementResult == SQLITE_OK) {
             // Check if the query is non-executable.
             if (!queryExecutable){


### PR DESCRIPTION
+ Use the correct data type to evaluate the error codes when
opening the SQLite database.

As mentioned in #757, I noticed some issues with the DB handling. I was trying to add code to migrate the database schema to allow adding new columns to the database, when I noticed that the new copying mechanism didn't work properly.

I don't quite understand why, but checking if the file exists at the new location always returns ` false` and the plugin attempts to copy the file again.

In some of my tests the copy then failed because the file already existed at that location.

But this is not even the main part of the problem. The actual problem is, that you never find out about this, because everything just silently fails.

I fixed the handling of the SQLite error codes in this PR, which should now show that the DB cannot be opened.

Before we simply evaluated the status wrong and usually just skipped all of the actual SQL queries.

Please, @bartekpacia have a look and give this a go on iOS.