### PR TITLE
[Android] Handles file creation failures when attempting to retry failed downloads

### DIFF
--- a/android/src/main/kotlin/vn/hunghd/flutterdownloader/DownloadWorker.kt
+++ b/android/src/main/kotlin/vn/hunghd/flutterdownloader/DownloadWorker.kt
@@ -497,17 +497,33 @@ class DownloadWorker(context: Context, params: WorkerParameters) :
     private fun createFileInAppSpecificDir(filename: String, savedDir: String): File? {
         val newFile = File(savedDir, filename)
         try {
-            val rs: Boolean = newFile.createNewFile()
-            if (rs) {
-                return newFile
-            } else {
-                logError("It looks like you are trying to save file in public storage but not setting 'saveInPublicStorage' to 'true'")
+            if (newFile.exists()) {
+                val deleted = newFile.delete()
+                if (!deleted) {
+                    logError("Unable to delete existing file: ${newFile.absolutePath}")
+                    return null
+                }
             }
+
+            val created: Boolean = newFile.createNewFile()
+            if (!created) {
+                logError(
+                    """
+                        Unable to create new file: ${newFile.absolutePath}.
+                         Are are trying to save file in public storage 
+                         but not setting 'saveInPublicStorage' to 'true'?
+                    """.trimIndent()
+                )
+                return null
+            }
+
+            return newFile
+
         } catch (e: IOException) {
             e.printStackTrace()
             logError("Create a file using java.io API failed ")
+            return null
         }
-        return null
     }
 
     /**


### PR DESCRIPTION
If new file creation fails, we [wrongly assume](https://github.com/fluttercommunity/flutter_downloader/blob/cc62a526119266e83c825f11b20c0dc00ea9ebd5/android/src/main/kotlin/vn/hunghd/flutterdownloader/DownloadWorker.kt#L504) that the user is creating a file in public storage but not setting `saveInPublicStorage` to `true`. File creation can, also, fail if the file already exists. There might be other IO cases as well (low memory etc.) where file creation fails.

Since we're creating a new file, I think it should be okay to overwrite any existing files with same file-path. If not, this PR fails to address the issue.

I have added some code to delete the existing file, and then, create the new file. I am not aware whether this issue exists on iOS side or not.

When I tried to retry some downloads, the android code will throw the null pointer exception since [`createFileInAppSpecificDir(String, String)`](https://github.com/fluttercommunity/flutter_downloader/blob/cc62a526119266e83c825f11b20c0dc00ea9ebd5/android/src/main/kotlin/vn/hunghd/flutterdownloader/DownloadWorker.kt#L497) returns null in this case.