### PR TITLE
[iOS] fix crash when allow_cellular is null on iOS

### DIFF
--- a/lib/src/downloader.dart
+++ b/lib/src/downloader.dart
@@ -162,7 +162,9 @@ class FlutterDownloader {
             filename: item['file_name'] as String?,
             savedDir: item['saved_dir'] as String,
             timeCreated: item['time_created'] as int,
-            allowCellular: item['allow_cellular'] as bool,
+
+            // allowCellular field is true by default (similar to enqueue())
+            allowCellular: (item['allow_cellular'] as bool?) ?? true,
           );
         },
       ).toList();


### PR DESCRIPTION
There's an issue on following line:
https://github.com/fluttercommunity/flutter_downloader/blob/cc62a526119266e83c825f11b20c0dc00ea9ebd5/lib/src/downloader.dart#L165

Here's the crash log:
```
flutter: |>|> download-manager initializing DownloaderDataSource
[VERBOSE-2:dart_vm_initializer.cc(41)] Unhandled Exception: type 'Null' is not a subtype of type 'bool' in type cast
#0      FlutterDownloader.loadTasks.<anonymous closure> (package:flutter_downloader/src/downloader.dart:165:51)
#1      MappedListIterable.elementAt (dart:_internal/iterable.dart:413:31)
#2      ListIterator.moveNext (dart:_internal/iterable.dart:342:26)
#3      new _GrowableList._ofEfficientLengthIterable (dart:core-patch/growable_array.dart:189:27)
#4      new _GrowableList.of (dart:core-patch/growable_array.dart:150:28)
#5      new List.of (dart:core-patch/array_patch.dart:51:28)
#6      ListIterable.toList (dart:_internal/iterable.dart:213:44)
#7      FlutterDownloader.loadTasks (package:flutter_downloader/src/downloader.dart:168:9)
<asynchronous suspension>
#8      FlutterDownloaderDataSourceImpl.initialize (package:notknown/src/downloadmanager/downloader/flutter_downloader_data_source.dart:36:19)
<asynchronous suspension>
#9      DownloadManagerImpl._initialize (package:notknown/<…>
```

`allow_cellular` is always null on iOS. I think we aren't even using it in iOS code since there's no mention of the term 'cellular' in there. Notice how it is missing in following lines:
https://github.com/fluttercommunity/flutter_downloader/blob/cc62a526119266e83c825f11b20c0dc00ea9ebd5/ios/Classes/FlutterDownloaderPlugin.m#L426
https://github.com/fluttercommunity/flutter_downloader/blob/cc62a526119266e83c825f11b20c0dc00ea9ebd5/ios/Classes/FlutterDownloaderPlugin.m#L591

As of now, to prevent the crash, I have updated `allow_cellular` to be `true` if it is null (as suggested by `enqueue(...)` function).
```
// allowCellular field is true by default (similar to enqueue())
allowCellular: (item['allow_cellular'] as bool?) ?? true,
```

I cannot fix the core issue because it requires someone with good experience on iOS side.