### PR TITLE
Fix allow_cellular error in iOS for loadTasksWithRawQuery

### DIFF
--- a/lib/src/downloader.dart
+++ b/lib/src/downloader.dart
@@ -222,7 +222,9 @@ class FlutterDownloader {
             filename: item['file_name'] as String?,
             savedDir: item['saved_dir'] as String,
             timeCreated: item['time_created'] as int,
-            allowCellular: item['allow_cellular'] as bool,
+
+            // allowCellular field is true by default (similar to enqueue())
+            allowCellular: (item['allow_cellular'] as bool?) ?? true,
           );
         },
       ).toList();


### PR DESCRIPTION
In the last update #774 was added the allowCellular default value, but only for the loadTasks function, it is needed also for loadTasksWithRawQuery (issue related: #786 )