### PR TITLE
fix: Create the application support directory if it does not already exist

### DIFF
--- a/ios/Classes/DBManager.m
+++ b/ios/Classes/DBManager.m
@@ -27,7 +27,20 @@
 -(instancetype)initWithDatabaseFilePath:(NSString *)dbFilePath{
     self = [super init];
     if (self) {
-        self.appDirectory = [NSSearchPathForDirectoriesInDomains(NSApplicationSupportDirectory, NSUserDomainMask, YES) firstObject];
+        // Get application support directory.
+        // Create the directory if it does not already exist.
+        NSError *error;
+        NSURL *appDirectoryUrl = [[NSFileManager defaultManager] URLForDirectory:NSApplicationSupportDirectory
+                                                                        inDomain:NSUserDomainMask
+                                                               appropriateForURL:nil
+                                                                          create:YES
+                                                                           error:&error];
+        self.appDirectory = appDirectoryUrl.path;
+        if (debug) {
+            if (error) {
+                NSLog(@"Get application support directory error: %@", error);
+            }
+        }
 
         // Keep the database filepath
         self.databaseFilePath = dbFilePath;


### PR DESCRIPTION
An error occurred getting the database file,  because the application support directory that stored the database file does not exist.

The directory could be created by this function [[URLForDirectory:inDomain:appropriateForURL:create:error:]](https://developer.apple.com/documentation/foundation/nsfilemanager/1407693-urlfordirectory/) lazily.


Related issues:

https://github.com/fluttercommunity/flutter_downloader/issues/786
https://github.com/fluttercommunity/flutter_downloader/issues/787
https://github.com/fluttercommunity/flutter_downloader/issues/814