### PR TITLE
remove that call [WidgetsFlutterBinding.ensureInitialized] in [initialize]

### DIFF
--- a/lib/src/downloader.dart
+++ b/lib/src/downloader.dart
@@ -51,8 +51,6 @@ class FlutterDownloader {
 
     _debug = debug;
 
-    WidgetsFlutterBinding.ensureInitialized();
-
     final callback = PluginUtilities.getCallbackHandle(callbackDispatcher)!;
     await _channel.invokeMethod<void>('initialize', <dynamic>[
       callback.toRawHandle(),


### PR DESCRIPTION
Calling UI function on Downloader Framework is non-standard, and it makes difficult to program in background isolation.

Better yet, call it outside the framework by user.

Related issue https://github.com/fluttercommunity/flutter_downloader/issues/809