### PR TITLE
fix: iOS apply tasks progress instead of computed progress on pause

### DIFF
--- a/ios/Classes/FlutterDownloaderPlugin.m
+++ b/ios/Classes/FlutterDownloaderPlugin.m
@@ -216,16 +216,9 @@ static NSMutableDictionary<NSString*, NSMutableDictionary*> *_runningTaskById = 
             NSString *taskIdValue = [weakSelf identifierForTask:download];
             if ([taskId isEqualToString:taskIdValue] && (state == NSURLSessionTaskStateRunning)) {
                 NSDictionary *task = [weakSelf loadTaskWithId:taskIdValue];
-                
-                int progress = 0;
-                if (download.countOfBytesExpectedToReceive > 0) {
-                    int64_t bytesReceived = download.countOfBytesReceived;
-                    int64_t bytesExpectedToReceive = download.countOfBytesExpectedToReceive;
-                    progress = round(bytesReceived * 100 / (double)bytesExpectedToReceive);
-                } else {
-                    NSNumber *progressNumOfTask = task[@"progress"];
-                    progress = progressNumOfTask.intValue;
-                }
+              
+                NSNumber *progressNumOfTask = task[@"progress"];
+                int progress = progressNumOfTask.intValue;
                 
                 [download cancelByProducingResumeData:^(NSData * _Nullable resumeData) {
                     // Save partial downloaded data to a file


### PR DESCRIPTION
`CountOfBytesReceived` is unreliable. Data inconsistency occurred.

We'd better manage the progress by `task map` and function `[URLSession:downloadTask:didWriteData:totalBytesWritten:totalBytesExpectedToWrite:]`

![checkonpause](https://user-images.githubusercontent.com/66350348/219361053-162017b3-826d-48c1-a736-c4d849bcd92d.png)
![checkonsuccess](https://user-images.githubusercontent.com/66350348/219361067-711d52bf-1e17-46de-94cf-6de5ea2345d2.png)


