### PR TITLE
Add namespace to `android/build.gradle`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.10.3
+
+- Fix Android build failing when using Android Gradle Plugin v8 (#857)
+
 ## 1.10.2
 
 - Correctly read the error/success codes (#766)

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -30,6 +30,8 @@ rootProject.allprojects {
 android {
     compileSdk 32
 
+    namespace "vn.hunghd.flutterdownloader"
+
     sourceSets {
         main.java.srcDirs += "src/main/kotlin"
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_downloader
 description: Powerful plugin making it easy to download files.
-version: 1.10.2
+version: 1.10.3
 repository: https://github.com/fluttercommunity/flutter_downloader
 issue_tracker: https://github.com/fluttercommunity/flutter_downloader/issues
 maintainer: Bartek Pacia (@bartekpacia)


### PR DESCRIPTION
This fixes Android build when using AGP v8.