### PR TITLE
Fix delete() not falling back to normal File#delete()

### DIFF
--- a/android/src/main/kotlin/vn/hunghd/flutterdownloader/FlutterDownloaderPlugin.kt
+++ b/android/src/main/kotlin/vn/hunghd/flutterdownloader/FlutterDownloaderPlugin.kt
@@ -6,6 +6,7 @@ import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.provider.MediaStore
+import android.util.Log
 import androidx.core.app.NotificationManagerCompat
 import androidx.work.BackoffPolicy
 import androidx.work.Constraints
@@ -390,7 +391,14 @@ class FlutterDownloaderPlugin : MethodChannel.MethodCallHandler, FlutterPlugin {
                 val saveFilePath = task.savedDir + File.separator + filename
                 val tempFile = File(saveFilePath)
                 if (tempFile.exists()) {
-                    deleteFileInMediaStore(tempFile)
+                    try {
+                        deleteFileInMediaStore(tempFile)
+                    } catch (e: SecurityException) {
+                        Log.d(
+                            "FlutterDownloader",
+                            "Failed to delete file in media store, will fall back to normal delete()"
+                        )
+                    }
                     tempFile.delete()
                 }
             }


### PR DESCRIPTION
When delete() was called, the plugin first tried to remove the file using MediaStore, and then was (trying to) fall back to normal File#delete(). Unfortunately, the calls to MediaStore were throwing a SecurityException, so the fall-back code was never executed.

This PR:
- fixes #413 
- fixes #496 
- fixes #773 (which was closed because OP found a workaround)