### PR TITLE
Don't crash when `FlutterDownloader.registerCallback()` wasn't called

### DIFF
--- a/lib/src/callback_dispatcher.dart
+++ b/lib/src/callback_dispatcher.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 import 'dart:ui';
 
 import 'package:flutter/services.dart';
@@ -16,18 +15,17 @@ void callbackDispatcher() {
     ..setMethodCallHandler((call) async {
       final args = call.arguments as List<dynamic>;
       final handle = CallbackHandle.fromRawHandle(args[0] as int);
+      final id = args[1] as String;
+      final status = args[2] as int;
+      final progress = args[3] as int;
+
       final callback = PluginUtilities.getCallbackFromHandle(handle) as void
           Function(String id, int status, int progress)?;
 
       if (callback == null) {
-        // ignore: avoid_print
-        print('fatal error: could not find callback');
-        exit(1);
+        // The callback wasn't registered. Ignore.
+        return;
       }
-
-      final id = args[1] as String;
-      final status = args[2] as int;
-      final progress = args[3] as int;
 
       callback(id, status, progress);
     })


### PR DESCRIPTION
Fixes #445