### PR TITLE
Fixed bug in the ios sanitizeFilename method

### DIFF
--- a/ios/Classes/FlutterDownloaderPlugin.m
+++ b/ios/Classes/FlutterDownloaderPlugin.m
@@ -370,7 +370,7 @@ static NSMutableDictionary<NSString*, NSMutableDictionary*> *_runningTaskById = 
 
 - (NSString *)sanitizeFilename:(nullable NSString *)filename {
     // Define a list of allowed characters for filenames
-    NSCharacterSet *allowedCharacters = [[NSCharacterSet characterSetWithCharactersInString:@"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_.() "] invertedSet];
+    NSCharacterSet *allowedCharacters = [NSCharacterSet characterSetWithCharactersInString:@"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_.() "];
 
     if (filename == nil || [filename isEqual:[NSNull null]] || [filename isEqualToString:@""]) {
            NSString *defaultFilename = @"default_filename";


### PR DESCRIPTION
Fixed bug in the ios sanitizeFilename method in ios/Classes/FlutterDownloaderPlugin.m.

It was calling `invertSet` on allowedCharacters which made it a set of disallowed characters, so the filename just becomes a list of '_' chars.