### PR TITLE
Rename DBManager to resolve name conflict with CallHistory private framework

### DIFF
--- a/ios/Classes/FlutterDownloaderDBManager.h
+++ b/ios/Classes/FlutterDownloaderDBManager.h
@@ -1,5 +1,5 @@
 //
-//  DBManager.h
+//  FlutterDownloaderDBManager.h
 //  Runner
 //
 //  Author: GABRIEL THEODOROPOULOS.
@@ -7,7 +7,7 @@
 
 #import <Foundation/Foundation.h>
 
-@interface DBManager : NSObject
+@interface FlutterDownloaderDBManager : NSObject
 
 @property (nonatomic, strong) NSMutableArray *arrColumnNames;
 

--- a/ios/Classes/FlutterDownloaderDBManager.m
+++ b/ios/Classes/FlutterDownloaderDBManager.m
@@ -1,14 +1,14 @@
 //
-//  DBManager.m
+//  FlutterDownloaderDBManager.m
 //  Runner
 //
 //  Author: GABRIEL THEODOROPOULOS.
 //
 
-#import "DBManager.h"
+#import "FlutterDownloaderDBManager.h"
 #import <sqlite3.h>
 
-@interface DBManager()
+@interface FlutterDownloaderDBManager()
 
 @property (nonatomic, strong) NSString *appDirectory;
 @property (nonatomic, strong) NSString *databaseFilePath;
@@ -20,7 +20,7 @@
 
 @end
 
-@implementation DBManager
+@implementation FlutterDownloaderDBManager
 
 @synthesize debug;
 

--- a/ios/Classes/FlutterDownloaderPlugin.m
+++ b/ios/Classes/FlutterDownloaderPlugin.m
@@ -1,5 +1,5 @@
 #import "FlutterDownloaderPlugin.h"
-#import "DBManager.h"
+#import "FlutterDownloaderDBManager.h"
 
 #define STATUS_UNDEFINED 0
 #define STATUS_ENQUEUED 1
@@ -35,7 +35,7 @@
     FlutterMethodChannel *_mainChannel;
     FlutterMethodChannel *_callbackChannel;
     NSObject<FlutterPluginRegistrar> *_registrar;
-    DBManager *_dbManager;
+    FlutterDownloaderDBManager *_dbManager;
     NSString *_allFilesDownloadedMsg;
     NSMutableArray *_eventQueue;
 }
@@ -94,7 +94,7 @@ static NSMutableDictionary<NSString*, NSMutableDictionary*> *_runningTaskById = 
         }
         databaseQueue = dispatch_queue_create("vn.hunghd.flutter_downloader", 0);
         
-        _dbManager = [[DBManager alloc] initWithDatabaseFilePath:dbPath];
+        _dbManager = [[FlutterDownloaderDBManager alloc] initWithDatabaseFilePath:dbPath];
         
         if (_runningTaskById == nil) {
             _runningTaskById = [[NSMutableDictionary alloc] init];


### PR DESCRIPTION
Hello!

I'm submitting this PR to address a public naming conflict of `DBManager` that is also being used in the PrivateFramework for CallHistory on iOS.   This PR contains no logic changes other than the simple renaming of `DBManager` to `FlutterDownloaderDBManager`.

![image](https://github.com/fluttercommunity/flutter_downloader/assets/124402948/c0c7ccb9-932c-44b3-b7f8-45e0242138d3)

Thank you for contribution to the Flutter Community!  Please let me know if you have any questions or requests regarding this Pull Request.  