### PR TITLE
feat: allow nullable content-type

### DIFF
--- a/android/src/main/kotlin/vn/hunghd/flutterdownloader/DownloadTask.kt
+++ b/android/src/main/kotlin/vn/hunghd/flutterdownloader/DownloadTask.kt
@@ -9,7 +9,7 @@ data class DownloadTask(
     var filename: String?,
     var savedDir: String,
     var headers: String,
-    var mimeType: String,
+    var mimeType: String?,
     var resumable: Boolean,
     var showNotification: Boolean,
     var openFileFromNotification: Boolean,

--- a/android/src/main/kotlin/vn/hunghd/flutterdownloader/DownloadTask.kt
+++ b/android/src/main/kotlin/vn/hunghd/flutterdownloader/DownloadTask.kt
@@ -9,7 +9,7 @@ data class DownloadTask(
     var filename: String?,
     var savedDir: String,
     var headers: String,
-    var mimeType: String?,
+    var mimeType: String,
     var resumable: Boolean,
     var showNotification: Boolean,
     var openFileFromNotification: Boolean,

--- a/android/src/main/kotlin/vn/hunghd/flutterdownloader/DownloadWorker.kt
+++ b/android/src/main/kotlin/vn/hunghd/flutterdownloader/DownloadWorker.kt
@@ -519,7 +519,7 @@ class DownloadWorker(context: Context, params: WorkerParameters) :
      * Create a file inside the Download folder using MediaStore API
      */
     @RequiresApi(Build.VERSION_CODES.Q)
-    private fun createFileInPublicDownloadsDir(filename: String?, mimeType: String): Uri? {
+    private fun createFileInPublicDownloadsDir(filename: String?, mimeType: String?): Uri? {
         val collection: Uri = MediaStore.Downloads.EXTERNAL_CONTENT_URI
         val values = ContentValues()
         values.put(MediaStore.Downloads.DISPLAY_NAME, filename)
@@ -772,7 +772,7 @@ class DownloadWorker(context: Context, params: WorkerParameters) :
         return contentType?.split(";")?.toTypedArray()?.get(0)?.trim { it <= ' ' }
     }
 
-    private fun isImageOrVideoFile(contentType: String): Boolean {
+    private fun isImageOrVideoFile(contentType: String?): Boolean {
         val newContentType = getContentTypeWithoutCharset(contentType)
         return newContentType != null && (newContentType.startsWith("image/") || newContentType.startsWith("video"))
     }

--- a/android/src/main/kotlin/vn/hunghd/flutterdownloader/DownloadWorker.kt
+++ b/android/src/main/kotlin/vn/hunghd/flutterdownloader/DownloadWorker.kt
@@ -338,12 +338,14 @@ class DownloadWorker(context: Context, params: WorkerParameters) :
                 break
             }
             httpConn!!.connect()
-            val contentType: String
+            val contentType: String?
             if ((responseCode == HttpURLConnection.HTTP_OK || isResume && responseCode == HttpURLConnection.HTTP_PARTIAL) && !isStopped) {
                 contentType = httpConn.contentType
                 val contentLength: Long =
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) httpConn.contentLengthLong else httpConn.contentLength.toLong()
-                log("Content-Type = $contentType")
+                if (contentType != null){
+                    log("Content-Type = $contentType")
+                }
                 log("Content-Length = $contentLength")
                 val charset = getCharsetFromContentType(contentType)
                 log("Charset = $charset")

--- a/android/src/main/kotlin/vn/hunghd/flutterdownloader/DownloadWorker.kt
+++ b/android/src/main/kotlin/vn/hunghd/flutterdownloader/DownloadWorker.kt
@@ -343,7 +343,7 @@ class DownloadWorker(context: Context, params: WorkerParameters) :
                 contentType = httpConn.contentType
                 val contentLength: Long =
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) httpConn.contentLengthLong else httpConn.contentLength.toLong()
-                if (contentType != null){
+                if (contentType != null) {
                     log("Content-Type = $contentType")
                 }
                 log("Content-Length = $contentLength")

--- a/android/src/main/kotlin/vn/hunghd/flutterdownloader/TaskDao.kt
+++ b/android/src/main/kotlin/vn/hunghd/flutterdownloader/TaskDao.kt
@@ -199,7 +199,7 @@ class TaskDao(private val dbHelper: TaskDbHelper) {
         val db = dbHelper.writableDatabase
         val values = ContentValues()
         values.put(TaskEntry.COLUMN_NAME_FILE_NAME, filename)
-        values.put(TaskEntry.COLUMN_NAME_MIME_TYPE, mimeType)
+        values.put(TaskEntry.COLUMN_NAME_MIME_TYPE, mimeType ?: "unknown")
         db.beginTransaction()
         try {
             db.update(


### PR DESCRIPTION
On Android when source had null content-type, the request fails and throws exception. It's unexpected behavior since there is nothing wrong with downloaded file.

Proposing to resolve https://github.com/fluttercommunity/flutter_downloader/issues/935 and https://github.com/fluttercommunity/flutter_downloader/issues/936