### PR TITLE
Add custom notification title for android

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,6 +385,7 @@ CREATE TABLE `task` (
   `saved_dir` TEXT,
   `resumable` TINYINT DEFAULT 0,
   `headers` TEXT,
+  `notification_title` TEXT,
   `show_notification` TINYINT DEFAULT 0,
   `open_file_from_notification` TINYINT DEFAULT 0,
   `time_created`  INTEGER DEFAULT 0

--- a/android/src/main/kotlin/vn/hunghd/flutterdownloader/DownloadTask.kt
+++ b/android/src/main/kotlin/vn/hunghd/flutterdownloader/DownloadTask.kt
@@ -11,6 +11,7 @@ data class DownloadTask(
     var headers: String,
     var mimeType: String?,
     var resumable: Boolean,
+    var notificationTitle: String?,
     var showNotification: Boolean,
     var openFileFromNotification: Boolean,
     var timeCreated: Long,

--- a/android/src/main/kotlin/vn/hunghd/flutterdownloader/FlutterDownloaderPlugin.kt
+++ b/android/src/main/kotlin/vn/hunghd/flutterdownloader/FlutterDownloaderPlugin.kt
@@ -86,6 +86,7 @@ class FlutterDownloaderPlugin : MethodChannel.MethodCallHandler, FlutterPlugin {
         savedDir: String?,
         filename: String?,
         headers: String?,
+        notificationTitle: String?,
         showNotification: Boolean,
         openFileFromNotification: Boolean,
         isResume: Boolean,
@@ -109,6 +110,7 @@ class FlutterDownloaderPlugin : MethodChannel.MethodCallHandler, FlutterPlugin {
                     .putString(DownloadWorker.ARG_SAVED_DIR, savedDir)
                     .putString(DownloadWorker.ARG_FILE_NAME, filename)
                     .putString(DownloadWorker.ARG_HEADERS, headers)
+                    .putString(DownloadWorker.ARG_NOTIFICATION_TITLE, notificationTitle)
                     .putBoolean(DownloadWorker.ARG_SHOW_NOTIFICATION, showNotification)
                     .putBoolean(
                         DownloadWorker.ARG_OPEN_FILE_FROM_NOTIFICATION,
@@ -165,6 +167,7 @@ class FlutterDownloaderPlugin : MethodChannel.MethodCallHandler, FlutterPlugin {
         val filename: String? = call.argument("file_name")
         val headers: String = call.requireArgument("headers")
         val timeout: Int = call.requireArgument("timeout")
+        val notificationTitle: String? = call.argument("notification_title")
         val showNotification: Boolean = call.requireArgument("show_notification")
         val openFileFromNotification: Boolean = call.requireArgument("open_file_from_notification")
         val requiresStorageNotLow: Boolean = call.requireArgument("requires_storage_not_low")
@@ -175,6 +178,7 @@ class FlutterDownloaderPlugin : MethodChannel.MethodCallHandler, FlutterPlugin {
             savedDir,
             filename,
             headers,
+            notificationTitle,
             showNotification,
             openFileFromNotification,
             false,
@@ -195,6 +199,7 @@ class FlutterDownloaderPlugin : MethodChannel.MethodCallHandler, FlutterPlugin {
             filename,
             savedDir,
             headers,
+            notificationTitle,
             showNotification,
             openFileFromNotification,
             saveInPublicStorage,
@@ -279,6 +284,7 @@ class FlutterDownloaderPlugin : MethodChannel.MethodCallHandler, FlutterPlugin {
                         task.savedDir,
                         task.filename,
                         task.headers,
+                        task.notificationTitle,
                         task.showNotification,
                         task.openFileFromNotification,
                         true,
@@ -323,7 +329,7 @@ class FlutterDownloaderPlugin : MethodChannel.MethodCallHandler, FlutterPlugin {
             if (task.status == DownloadStatus.FAILED || task.status == DownloadStatus.CANCELED) {
                 val request: WorkRequest = buildRequest(
                     task.url, task.savedDir, task.filename,
-                    task.headers, task.showNotification, task.openFileFromNotification,
+                    task.headers, task.notificationTitle, task.showNotification, task.openFileFromNotification,
                     false, requiresStorageNotLow, task.saveInPublicStorage, timeout, allowCellular = task.allowCellular
                 )
                 val newTaskId: String = request.id.toString()

--- a/android/src/main/kotlin/vn/hunghd/flutterdownloader/TaskDao.kt
+++ b/android/src/main/kotlin/vn/hunghd/flutterdownloader/TaskDao.kt
@@ -18,6 +18,7 @@ class TaskDao(private val dbHelper: TaskDbHelper) {
         TaskEntry.COLUMN_NAME_MIME_TYPE,
         TaskEntry.COLUMN_NAME_RESUMABLE,
         TaskEntry.COLUMN_NAME_OPEN_FILE_FROM_NOTIFICATION,
+        TaskEntry.COLUMN_NAME_NOTIFICATION_TITLE,
         TaskEntry.COLUMN_NAME_SHOW_NOTIFICATION,
         TaskEntry.COLUMN_NAME_TIME_CREATED,
         TaskEntry.COLUMN_SAVE_IN_PUBLIC_STORAGE,
@@ -32,6 +33,7 @@ class TaskDao(private val dbHelper: TaskDbHelper) {
         fileName: String?,
         savedDir: String?,
         headers: String?,
+        notificationTitle: String?,
         showNotification: Boolean,
         openFileFromNotification: Boolean,
         saveInPublicStorage: Boolean,
@@ -47,6 +49,7 @@ class TaskDao(private val dbHelper: TaskDbHelper) {
         values.put(TaskEntry.COLUMN_NAME_SAVED_DIR, savedDir)
         values.put(TaskEntry.COLUMN_NAME_HEADERS, headers)
         values.put(TaskEntry.COLUMN_NAME_MIME_TYPE, "unknown")
+        values.put(TaskEntry.COLUMN_NAME_NOTIFICATION_TITLE, notificationTitle)
         values.put(TaskEntry.COLUMN_NAME_SHOW_NOTIFICATION, if (showNotification) 1 else 0)
         values.put(
             TaskEntry.COLUMN_NAME_OPEN_FILE_FROM_NOTIFICATION,
@@ -242,6 +245,7 @@ class TaskDao(private val dbHelper: TaskDbHelper) {
         val headers = cursor.getString(cursor.getColumnIndexOrThrow(TaskEntry.COLUMN_NAME_HEADERS))
         val mimeType = cursor.getString(cursor.getColumnIndexOrThrow(TaskEntry.COLUMN_NAME_MIME_TYPE))
         val resumable = cursor.getShort(cursor.getColumnIndexOrThrow(TaskEntry.COLUMN_NAME_RESUMABLE)).toInt()
+        val notificationTitle = cursor.getString(cursor.getColumnIndexOrThrow(TaskEntry.COLUMN_NAME_NOTIFICATION_TITLE))
         val showNotification = cursor.getShort(cursor.getColumnIndexOrThrow(TaskEntry.COLUMN_NAME_SHOW_NOTIFICATION)).toInt()
         val clickToOpenDownloadedFile = cursor.getShort(cursor.getColumnIndexOrThrow(TaskEntry.COLUMN_NAME_OPEN_FILE_FROM_NOTIFICATION)).toInt()
         val timeCreated = cursor.getLong(cursor.getColumnIndexOrThrow(TaskEntry.COLUMN_NAME_TIME_CREATED))
@@ -258,6 +262,7 @@ class TaskDao(private val dbHelper: TaskDbHelper) {
             headers,
             mimeType,
             resumable == 1,
+            notificationTitle,
             showNotification == 1,
             clickToOpenDownloadedFile == 1,
             timeCreated,

--- a/android/src/main/kotlin/vn/hunghd/flutterdownloader/TaskDbHelper.kt
+++ b/android/src/main/kotlin/vn/hunghd/flutterdownloader/TaskDbHelper.kt
@@ -15,6 +15,7 @@ class TaskDbHelper private constructor(context: Context) :
         update1to2(db, oldVersion)
         update2to3(db, oldVersion)
         update3to4(db, oldVersion)
+        update4to5(db, oldVersion)
     }
 
     private fun update1to2(db: SQLiteDatabase, oldVersion: Int) {
@@ -39,12 +40,19 @@ class TaskDbHelper private constructor(context: Context) :
         db.execSQL("ALTER TABLE ${TaskEntry.TABLE_NAME} ADD COLUMN ${TaskEntry.COLUMN_ALLOW_CELLULAR} TINYINT DEFAULT 1")
     }
 
+    private fun update4to5(db: SQLiteDatabase, oldVersion: Int) {
+        if (oldVersion > 4) {
+            return
+        }
+        db.execSQL("ALTER TABLE ${TaskEntry.TABLE_NAME} ADD COLUMN ${TaskEntry.COLUMN_NAME_NOTIFICATION_TITLE} TEXT")
+    }
+
     override fun onDowngrade(db: SQLiteDatabase, oldVersion: Int, newVersion: Int) {
         onUpgrade(db, oldVersion, newVersion)
     }
 
     companion object {
-        const val DATABASE_VERSION = 4
+        const val DATABASE_VERSION = 5
         const val DATABASE_NAME = "download_tasks.db"
         private var instance: TaskDbHelper? = null
         private const val SQL_CREATE_ENTRIES = (
@@ -59,6 +67,7 @@ class TaskDbHelper private constructor(context: Context) :
                 TaskEntry.COLUMN_NAME_HEADERS + " TEXT, " +
                 TaskEntry.COLUMN_NAME_MIME_TYPE + " VARCHAR(128), " +
                 TaskEntry.COLUMN_NAME_RESUMABLE + " TINYINT DEFAULT 0, " +
+                TaskEntry.COLUMN_NAME_NOTIFICATION_TITLE + " TEXT, " +
                 TaskEntry.COLUMN_NAME_SHOW_NOTIFICATION + " TINYINT DEFAULT 0, " +
                 TaskEntry.COLUMN_NAME_OPEN_FILE_FROM_NOTIFICATION + " TINYINT DEFAULT 0, " +
                 TaskEntry.COLUMN_NAME_TIME_CREATED + " INTEGER DEFAULT 0, " +

--- a/android/src/main/kotlin/vn/hunghd/flutterdownloader/TaskEntry.kt
+++ b/android/src/main/kotlin/vn/hunghd/flutterdownloader/TaskEntry.kt
@@ -13,6 +13,7 @@ object TaskEntry : BaseColumns {
     const val COLUMN_NAME_MIME_TYPE = "mime_type"
     const val COLUMN_NAME_RESUMABLE = "resumable"
     const val COLUMN_NAME_HEADERS = "headers"
+    const val COLUMN_NAME_NOTIFICATION_TITLE = "notification_title"
     const val COLUMN_NAME_SHOW_NOTIFICATION = "show_notification"
     const val COLUMN_NAME_OPEN_FILE_FROM_NOTIFICATION = "open_file_from_notification"
     const val COLUMN_NAME_TIME_CREATED = "time_created"

--- a/lib/src/downloader.dart
+++ b/lib/src/downloader.dart
@@ -74,6 +74,9 @@ class FlutterDownloader {
   ///
   /// ### Android-only
   ///
+  /// [notificationTitle] is the title of the notification shown during the
+  /// download. If it is null, the title is determined from the fileName or HTTP response.
+  ///
   /// If [showNotification] is true, a notification with the current download
   /// progress will be shown.
   ///
@@ -96,6 +99,7 @@ class FlutterDownloader {
     required String savedDir,
     String? fileName,
     Map<String, String> headers = const {},
+    String? notificationTitle,
     bool showNotification = true,
     bool openFileFromNotification = true,
     bool requiresStorageNotLow = true,
@@ -112,6 +116,7 @@ class FlutterDownloader {
         'saved_dir': savedDir,
         'file_name': fileName,
         'headers': jsonEncode(headers),
+        'notification_title': notificationTitle,
         'show_notification': showNotification,
         'open_file_from_notification': openFileFromNotification,
         'requires_storage_not_low': requiresStorageNotLow,


### PR DESCRIPTION
Adds support for setting a custom notification title for a new task through the `notificationTitle` parameter in the `enqueue` method. If no `notificationTitle` is provided, the notification will default to displaying the URL or filename as the title.